### PR TITLE
Tim/feat/s3 object path selectors

### DIFF
--- a/docs/docs.md
+++ b/docs/docs.md
@@ -3069,7 +3069,7 @@ type IrminAPIPaginationMetadata struct {
     // Number of items per page
     PerPage *int `json:"per_page,omitempty"    validate:"omitempty,gte=1" example:"20"`
     // Total number of pages available
-    TotalPages *int `json:"total_pages,omitempty" validate:"omitempty,gte=1" example:"8"`
+    TotalPages *int `json:"total_pages,omitempty" validate:"omitempty,gte=0" example:"8"`
     // HasMore indicates if there are more items available
     HasMore *bool `json:"has_more,omitempty"                               example:"true"`
     // Next is the next page number or token, if applicable
@@ -3214,7 +3214,8 @@ type Object struct {
     SizeBytes             int64             `json:"size_bytes,omitempty"              validate:"omitempty,min=0"                        example:"1048576"`
     LastModified          string            `json:"last_modified,omitempty"                                                             example:"2025-12-01T14:22:30Z"`
     Metadata              map[string]string `json:"metadata,omitempty"`
-    SQLSelectorExample    string            `json:"sql_selector_example,omitempty"` // Constructed SQL selector for the object, like $["workspace;repo;file.json@main"]
+    S3PathSelector        string            `json:"s3_path_selector,omitempty"        validate:"omitempty"                              example:"s3://workspace-slug-repository-slug/main/file.json"`
+    SQLSelector           string            `json:"sql_selector,omitempty"            validate:"omitempty"                              example:"$['workspace-slug;repository-slug;file.json@main']"`
     Tags                  []Tag             `json:"tags,omitempty"                    validate:"dive,omitempty"`
     Children              []Object          `json:"children,omitempty"                validate:"dive,omitempty"`
 }
@@ -3227,19 +3228,20 @@ type Object struct {
 
 ```go
 type ObjectSchema struct {
-    Name               string     `json:"name"                           validate:"max=255"                                             example:"customers.json"`
-    Path               string     `json:"path"                                                                                          example:"/data/customers/customers.json"`
-    Type               ObjectType `json:"type"                           validate:"required,oneof=group structured binary"              example:"structured"`
-    LastModified       *string    `json:"last_modified,omitempty"                                                                       example:"2025-12-01T14:22:30Z"`
-    Description        *string    `json:"description,omitempty"                                                                         example:"Customer data in JSON format with contact information"`
-    SQLSelectorExample *string    `json:"sql_selector_example,omitempty"                                                                example:"$['workspace;repo;file.json@main']"`
+    Name           string     `json:"name"                       validate:"max=255"                                             example:"customers.json"`
+    Path           string     `json:"path"                                                                                      example:"/data/customers/customers.json"`
+    Type           ObjectType `json:"type"                       validate:"required,oneof=group structured binary"              example:"structured"`
+    LastModified   *string    `json:"last_modified,omitempty"                                                                   example:"2025-12-01T14:22:30Z"`
+    Description    *string    `json:"description,omitempty"                                                                     example:"Customer data in JSON format with contact information"`
+    S3PathSelector string     `json:"s3_path_selector,omitempty" validate:"omitempty"                                           example:"s3://workspace-slug-repository-slug/main/file.json"`
+    SQLSelector    string     `json:"sql_selector,omitempty"     validate:"omitempty"                                           example:"$['workspace-slug;repository-slug;file.json@main']"`
     // Structured schema
-    Schema *JSONSchema `json:"schema,omitempty"               validate:"required_if=Type structured"`
+    Schema *JSONSchema `json:"schema,omitempty"           validate:"required_if=Type structured"`
     // Structured or Binary schema
-    Size        *int    `json:"size,omitempty"                                                                                example:"1048576"`
-    ContentType *string `json:"content_type,omitempty"         validate:"required_if=Type binary,required_if=Type structured" example:"application/json"`
+    Size        *int    `json:"size,omitempty"                                                                            example:"1048576"`
+    ContentType *string `json:"content_type,omitempty"     validate:"required_if=Type binary,required_if=Type structured" example:"application/json"`
     // Group schema
-    Children     []ObjectSchema           `json:"children,omitempty"             validate:"dive,required_if=Type group"`
+    Children     []ObjectSchema           `json:"children,omitempty"         validate:"dive,required_if=Type group"`
     Restrictions *GroupSchemaRestrictions `json:"restrictions,omitempty"` // Restrictions are not required, but are available for group schemas
 }
 ```

--- a/docs/html/github_com_IrminData_irmin-sdk-go_models.html
+++ b/docs/html/github_com_IrminData_irmin-sdk-go_models.html
@@ -293,7 +293,7 @@ type IrminAPIPaginationMetadata struct {
 	// Number of items per page
 	PerPage *int `json:"per_page,omitempty"    validate:"omitempty,gte=1" example:"20"`
 	// Total number of pages available
-	TotalPages *int `json:"total_pages,omitempty" validate:"omitempty,gte=1" example:"8"`
+	TotalPages *int `json:"total_pages,omitempty" validate:"omitempty,gte=0" example:"8"`
 	// HasMore indicates if there are more items available
 	HasMore *bool `json:"has_more,omitempty"                               example:"true"`
 	// Next is the next page number or token, if applicable
@@ -393,25 +393,27 @@ type Object struct {
 	SizeBytes             int64             `json:"size_bytes,omitempty"              validate:"omitempty,min=0"                        example:"1048576"`
 	LastModified          string            `json:"last_modified,omitempty"                                                             example:"2025-12-01T14:22:30Z"`
 	Metadata              map[string]string `json:"metadata,omitempty"`
-	SQLSelectorExample    string            `json:"sql_selector_example,omitempty"` // Constructed SQL selector for the object, like $["workspace;repo;file.json@main"]
+	S3PathSelector        string            `json:"s3_path_selector,omitempty"        validate:"omitempty"                              example:"s3://workspace-slug-repository-slug/main/file.json"`
+	SQLSelector           string            `json:"sql_selector,omitempty"            validate:"omitempty"                              example:"$['workspace-slug;repository-slug;file.json@main']"`
 	Tags                  []Tag             `json:"tags,omitempty"                    validate:"dive,omitempty"`
 	Children              []Object          `json:"children,omitempty"                validate:"dive,omitempty"`
 }
 
 type ObjectSchema struct {
-	Name               string     `json:"name"                           validate:"max=255"                                             example:"customers.json"`
-	Path               string     `json:"path"                                                                                          example:"/data/customers/customers.json"`
-	Type               ObjectType `json:"type"                           validate:"required,oneof=group structured binary"              example:"structured"`
-	LastModified       *string    `json:"last_modified,omitempty"                                                                       example:"2025-12-01T14:22:30Z"`
-	Description        *string    `json:"description,omitempty"                                                                         example:"Customer data in JSON format with contact information"`
-	SQLSelectorExample *string    `json:"sql_selector_example,omitempty"                                                                example:"$['workspace;repo;file.json@main']"`
+	Name           string     `json:"name"                       validate:"max=255"                                             example:"customers.json"`
+	Path           string     `json:"path"                                                                                      example:"/data/customers/customers.json"`
+	Type           ObjectType `json:"type"                       validate:"required,oneof=group structured binary"              example:"structured"`
+	LastModified   *string    `json:"last_modified,omitempty"                                                                   example:"2025-12-01T14:22:30Z"`
+	Description    *string    `json:"description,omitempty"                                                                     example:"Customer data in JSON format with contact information"`
+	S3PathSelector string     `json:"s3_path_selector,omitempty" validate:"omitempty"                                           example:"s3://workspace-slug-repository-slug/main/file.json"`
+	SQLSelector    string     `json:"sql_selector,omitempty"     validate:"omitempty"                                           example:"$['workspace-slug;repository-slug;file.json@main']"`
 	// Structured schema
-	Schema *JSONSchema `json:"schema,omitempty"               validate:"required_if=Type structured"`
+	Schema *JSONSchema `json:"schema,omitempty"           validate:"required_if=Type structured"`
 	// Structured or Binary schema
-	Size        *int    `json:"size,omitempty"                                                                                example:"1048576"`
-	ContentType *string `json:"content_type,omitempty"         validate:"required_if=Type binary,required_if=Type structured" example:"application/json"`
+	Size        *int    `json:"size,omitempty"                                                                            example:"1048576"`
+	ContentType *string `json:"content_type,omitempty"     validate:"required_if=Type binary,required_if=Type structured" example:"application/json"`
 	// Group schema
-	Children     []ObjectSchema           `json:"children,omitempty"             validate:"dive,required_if=Type group"`
+	Children     []ObjectSchema           `json:"children,omitempty"         validate:"dive,required_if=Type group"`
 	Restrictions *GroupSchemaRestrictions `json:"restrictions,omitempty"` // Restrictions are not required, but are available for group schemas
 }
 

--- a/docs/html/index.html
+++ b/docs/html/index.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8"/>
 <title>github.com/IrminData/irmin-sdk-go documentation</title>
 <h1>github.com/IrminData/irmin-sdk-go documentation</h1>
-<p>Generated on 2025-12-11 17:55 UTC</p>
+<p>Generated on 2025-12-12 12:43 UTC</p>
 <ul>
 <li><a href="github_com_IrminData_irmin-sdk-go.html">github.com/IrminData/irmin-sdk-go</a></li>
 <li><a href="github_com_IrminData_irmin-sdk-go_api.html">github.com/IrminData/irmin-sdk-go/api</a></li>

--- a/models/object.go
+++ b/models/object.go
@@ -25,7 +25,8 @@ type Object struct {
 	SizeBytes             int64             `json:"size_bytes,omitempty"              validate:"omitempty,min=0"                        example:"1048576"`
 	LastModified          string            `json:"last_modified,omitempty"                                                             example:"2025-12-01T14:22:30Z"`
 	Metadata              map[string]string `json:"metadata,omitempty"`
-	SQLSelectorExample    string            `json:"sql_selector_example,omitempty"` // Constructed SQL selector for the object, like $["workspace;repo;file.json@main"]
+	S3PathSelector        string            `json:"s3_path_selector,omitempty"        validate:"omitempty"                              example:"s3://workspace-slug-repository-slug/main/file.json"`
+	SQLSelector           string            `json:"sql_selector,omitempty"            validate:"omitempty"                              example:"$['workspace-slug;repository-slug;file.json@main']"`
 	Tags                  []Tag             `json:"tags,omitempty"                    validate:"dive,omitempty"`
 	Children              []Object          `json:"children,omitempty"                validate:"dive,omitempty"`
 }

--- a/models/objectSchema.go
+++ b/models/objectSchema.go
@@ -1,19 +1,20 @@
 package irminmodels
 
 type ObjectSchema struct {
-	Name               string     `json:"name"                           validate:"max=255"                                             example:"customers.json"`
-	Path               string     `json:"path"                                                                                          example:"/data/customers/customers.json"`
-	Type               ObjectType `json:"type"                           validate:"required,oneof=group structured binary"              example:"structured"`
-	LastModified       *string    `json:"last_modified,omitempty"                                                                       example:"2025-12-01T14:22:30Z"`
-	Description        *string    `json:"description,omitempty"                                                                         example:"Customer data in JSON format with contact information"`
-	SQLSelectorExample *string    `json:"sql_selector_example,omitempty"                                                                example:"$['workspace;repo;file.json@main']"`
+	Name           string     `json:"name"                       validate:"max=255"                                             example:"customers.json"`
+	Path           string     `json:"path"                                                                                      example:"/data/customers/customers.json"`
+	Type           ObjectType `json:"type"                       validate:"required,oneof=group structured binary"              example:"structured"`
+	LastModified   *string    `json:"last_modified,omitempty"                                                                   example:"2025-12-01T14:22:30Z"`
+	Description    *string    `json:"description,omitempty"                                                                     example:"Customer data in JSON format with contact information"`
+	S3PathSelector string     `json:"s3_path_selector,omitempty" validate:"omitempty"                                           example:"s3://workspace-slug-repository-slug/main/file.json"`
+	SQLSelector    string     `json:"sql_selector,omitempty"     validate:"omitempty"                                           example:"$['workspace-slug;repository-slug;file.json@main']"`
 	// Structured schema
-	Schema *JSONSchema `json:"schema,omitempty"               validate:"required_if=Type structured"`
+	Schema *JSONSchema `json:"schema,omitempty"           validate:"required_if=Type structured"`
 	// Structured or Binary schema
-	Size        *int    `json:"size,omitempty"                                                                                example:"1048576"`
-	ContentType *string `json:"content_type,omitempty"         validate:"required_if=Type binary,required_if=Type structured" example:"application/json"`
+	Size        *int    `json:"size,omitempty"                                                                            example:"1048576"`
+	ContentType *string `json:"content_type,omitempty"     validate:"required_if=Type binary,required_if=Type structured" example:"application/json"`
 	// Group schema
-	Children     []ObjectSchema           `json:"children,omitempty"             validate:"dive,required_if=Type group"`
+	Children     []ObjectSchema           `json:"children,omitempty"         validate:"dive,required_if=Type group"`
 	Restrictions *GroupSchemaRestrictions `json:"restrictions,omitempty"` // Restrictions are not required, but are available for group schemas
 }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduce `s3_path_selector` and `sql_selector` fields to `Object` and `ObjectSchema`, replacing the previous `sql_selector_example`.
> 
> - **Models**:
>   - `models/object.go`:
>     - Add `S3PathSelector` and `SQLSelector` fields with `omitempty` validation and examples.
>     - Remove `SQLSelectorExample` field.
>   - `models/objectSchema.go`:
>     - Add `S3PathSelector` and `SQLSelector` fields with `omitempty` validation and examples.
>     - Remove `SQLSelectorExample` field.
> - **Validation/Examples**:
>   - Ensure new selector fields include example formats and basic `omitempty` validation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 02b7f09d8efa1a140f012265c83c8849a679e59f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->