### PR TITLE
Tim/feat/script and query templates

### DIFF
--- a/api/queries.go
+++ b/api/queries.go
@@ -48,6 +48,21 @@ func (c *Client) ListStoredQueries(
 	return storedQueries, apiResp, nil
 }
 
+func (c *Client) ListQueryTemplates(
+	ctx context.Context,
+	workspace string,
+) ([]irminmodels.Template, *irminmodels.IrminAPIResponse, error) {
+	var templates []irminmodels.Template
+	apiResp, err := c.FetchAPI(ctx, RequestOptions{
+		Method:   http.MethodGet,
+		Endpoint: fmt.Sprintf("/v1/workspaces/%s/queries/templates", workspace),
+	}, &templates)
+	if err != nil {
+		return nil, nil, fmt.Errorf("fetch query templates error: %w", err)
+	}
+	return templates, apiResp, nil
+}
+
 func (c *Client) GetStoredQuery(
 	ctx context.Context,
 	workspace, queryID string,

--- a/api/script.go
+++ b/api/script.go
@@ -50,6 +50,21 @@ func (c *Client) ListStoredScripts(
 	return storedScripts, apiResp, nil
 }
 
+func (c *Client) ListScriptTemplates(
+	ctx context.Context,
+	workspace string,
+) ([]irminmodels.Template, *irminmodels.IrminAPIResponse, error) {
+	var templates []irminmodels.Template
+	apiResp, err := c.FetchAPI(ctx, RequestOptions{
+		Method:   http.MethodGet,
+		Endpoint: fmt.Sprintf("/v1/workspaces/%s/scripts/templates", workspace),
+	}, &templates)
+	if err != nil {
+		return nil, nil, fmt.Errorf("fetch script templates error: %w", err)
+	}
+	return templates, apiResp, nil
+}
+
 func (c *Client) GetStoredScript(
 	ctx context.Context,
 	workspace, scriptID string,

--- a/docs/docs.md
+++ b/docs/docs.md
@@ -226,8 +226,10 @@ import "github.com/IrminData/irmin-sdk-go/api"
   - [func \(c \*Client\) ListInviteInbox\(ctx context.Context\) \(\[\]irminmodels.Invite, \*irminmodels.IrminAPIResponse, error\)](<#Client.ListInviteInbox>)
   - [func \(c \*Client\) ListInvitesToWorkspace\(ctx context.Context, workspace string\) \(\[\]irminmodels.Invite, \*irminmodels.IrminAPIResponse, error\)](<#Client.ListInvitesToWorkspace>)
   - [func \(c \*Client\) ListPolicies\(ctx context.Context, workspace string, params ListPoliciesParams\) \(\[\]irminmodels.Policy, \*irminmodels.IrminAPIResponse, error\)](<#Client.ListPolicies>)
+  - [func \(c \*Client\) ListQueryTemplates\(ctx context.Context, workspace string\) \(\[\]irminmodels.Template, \*irminmodels.IrminAPIResponse, error\)](<#Client.ListQueryTemplates>)
   - [func \(c \*Client\) ListRepositories\(ctx context.Context, workspace string\) \(\[\]irminmodels.Repository, \*irminmodels.IrminAPIResponse, error\)](<#Client.ListRepositories>)
   - [func \(c \*Client\) ListRoles\(ctx context.Context\) \(\[\]irminmodels.Role, \*irminmodels.IrminAPIResponse, error\)](<#Client.ListRoles>)
+  - [func \(c \*Client\) ListScriptTemplates\(ctx context.Context, workspace string\) \(\[\]irminmodels.Template, \*irminmodels.IrminAPIResponse, error\)](<#Client.ListScriptTemplates>)
   - [func \(c \*Client\) ListStoredQueries\(ctx context.Context, workspace string\) \(\[\]irminmodels.StoredQuery, \*irminmodels.IrminAPIResponse, error\)](<#Client.ListStoredQueries>)
   - [func \(c \*Client\) ListStoredScripts\(ctx context.Context, workspace string\) \(\[\]irminmodels.StoredScript, \*irminmodels.IrminAPIResponse, error\)](<#Client.ListStoredScripts>)
   - [func \(c \*Client\) ListTags\(ctx context.Context, workspace, repository string\) \(\[\]irminmodels.GitTag, \*irminmodels.IrminAPIResponse, error\)](<#Client.ListTags>)
@@ -1164,6 +1166,15 @@ func (c *Client) ListPolicies(ctx context.Context, workspace string, params List
 
 ListPolicies returns a list of all policies for a workspace.
 
+<a name="Client.ListQueryTemplates"></a>
+### func \(\*Client\) ListQueryTemplates
+
+```go
+func (c *Client) ListQueryTemplates(ctx context.Context, workspace string) ([]irminmodels.Template, *irminmodels.IrminAPIResponse, error)
+```
+
+
+
 <a name="Client.ListRepositories"></a>
 ### func \(\*Client\) ListRepositories
 
@@ -1178,6 +1189,15 @@ func (c *Client) ListRepositories(ctx context.Context, workspace string) ([]irmi
 
 ```go
 func (c *Client) ListRoles(ctx context.Context) ([]irminmodels.Role, *irminmodels.IrminAPIResponse, error)
+```
+
+
+
+<a name="Client.ListScriptTemplates"></a>
+### func \(\*Client\) ListScriptTemplates
+
+```go
+func (c *Client) ListScriptTemplates(ctx context.Context, workspace string) ([]irminmodels.Template, *irminmodels.IrminAPIResponse, error)
 ```
 
 
@@ -2591,6 +2611,9 @@ import "github.com/IrminData/irmin-sdk-go/models"
 - [type TagEntityType](<#TagEntityType>)
 - [type TagWithAssets](<#TagWithAssets>)
 - [type TaggedAssets](<#TaggedAssets>)
+- [type Template](<#Template>)
+- [type TemplateLanguage](<#TemplateLanguage>)
+- [type TemplateType](<#TemplateType>)
 - [type User](<#User>)
 - [type UserPolicySummary](<#UserPolicySummary>)
 - [type Workflow](<#Workflow>)
@@ -3868,6 +3891,60 @@ type TaggedAssets struct {
     Connections       []Connection   `json:"connections"        validate:"dive"`
     RepositoryObjects []Object       `json:"repository_objects" validate:"dive"`
 }
+```
+
+<a name="Template"></a>
+## type Template
+
+Template represents a template from which a script or query can be created.
+
+```go
+type Template struct {
+    ID           string           `json:"id"           validate:"required,validsqid=templates" example:"tpl_2k8n9q1m7p3x4z"`
+    Title        string           `json:"title"        validate:"required,max=100"             example:"My Template"`
+    Description  string           `json:"description"  validate:"required,max=255"             example:"This is a template for my application"`
+    Content      string           `json:"content"      validate:"required,max=10000"           example:"This is the content of my template"`
+    Type         TemplateType     `json:"type"         validate:"required,max=50"              example:"script"`
+    Language     TemplateLanguage `json:"language"     validate:"required,max=50"              example:"go"`
+    Tags         []string         `json:"tags"         validate:"required,dive"                example:"tag1,tag2,tag3"`
+    Placeholders []string         `json:"placeholders" validate:"omitempty,dive,max=100"       example:"repository_slug,branch_name"`
+}
+```
+
+<a name="TemplateLanguage"></a>
+## type TemplateLanguage
+
+
+
+```go
+type TemplateLanguage string
+```
+
+<a name="TemplateLanguageGo"></a>
+
+```go
+const (
+    TemplateLanguageGo  TemplateLanguage = "go"
+    TemplateLanguageSQL TemplateLanguage = "sql"
+)
+```
+
+<a name="TemplateType"></a>
+## type TemplateType
+
+
+
+```go
+type TemplateType string
+```
+
+<a name="TemplateTypeScript"></a>
+
+```go
+const (
+    TemplateTypeScript TemplateType = "script"
+    TemplateTypeQuery  TemplateType = "query"
+)
 ```
 
 <a name="User"></a>

--- a/docs/html/github_com_IrminData_irmin-sdk-go_api.html
+++ b/docs/html/github_com_IrminData_irmin-sdk-go_api.html
@@ -533,12 +533,22 @@ func (c *Client) ListPolicies(
 ) ([]irminmodels.Policy, *irminmodels.IrminAPIResponse, error)
     ListPolicies returns a list of all policies for a workspace.
 
+func (c *Client) ListQueryTemplates(
+	ctx context.Context,
+	workspace string,
+) ([]irminmodels.Template, *irminmodels.IrminAPIResponse, error)
+
 func (c *Client) ListRepositories(
 	ctx context.Context,
 	workspace string,
 ) ([]irminmodels.Repository, *irminmodels.IrminAPIResponse, error)
 
 func (c *Client) ListRoles(ctx context.Context) ([]irminmodels.Role, *irminmodels.IrminAPIResponse, error)
+
+func (c *Client) ListScriptTemplates(
+	ctx context.Context,
+	workspace string,
+) ([]irminmodels.Template, *irminmodels.IrminAPIResponse, error)
 
 func (c *Client) ListStoredQueries(
 	ctx context.Context,

--- a/docs/html/github_com_IrminData_irmin-sdk-go_models.html
+++ b/docs/html/github_com_IrminData_irmin-sdk-go_models.html
@@ -803,6 +803,30 @@ type TaggedAssets struct {
 }
     TaggedAssets represents all assets associated with a specific tag.
 
+type Template struct {
+	ID           string           `json:"id"           validate:"required,validsqid=templates" example:"tpl_2k8n9q1m7p3x4z"`
+	Title        string           `json:"title"        validate:"required,max=100"             example:"My Template"`
+	Description  string           `json:"description"  validate:"required,max=255"             example:"This is a template for my application"`
+	Content      string           `json:"content"      validate:"required,max=10000"           example:"This is the content of my template"`
+	Type         TemplateType     `json:"type"         validate:"required,max=50"              example:"script"`
+	Language     TemplateLanguage `json:"language"     validate:"required,max=50"              example:"go"`
+	Tags         []string         `json:"tags"         validate:"required,dive"                example:"tag1,tag2,tag3"`
+	Placeholders []string         `json:"placeholders" validate:"omitempty,dive,max=100"       example:"repository_slug,branch_name"`
+}
+    Template represents a template from which a script or query can be created.
+
+type TemplateLanguage string
+
+const (
+	TemplateLanguageGo  TemplateLanguage = "go"
+	TemplateLanguageSQL TemplateLanguage = "sql"
+)
+type TemplateType string
+
+const (
+	TemplateTypeScript TemplateType = "script"
+	TemplateTypeQuery  TemplateType = "query"
+)
 type User struct {
 	ID             string `json:"id"              validate:"required,validsqid=users" example:"usr_2k8n9q1m7p3x4z"`
 	FirstName      string `json:"first_name"      validate:"required,max=50"          example:"John"`

--- a/docs/html/index.html
+++ b/docs/html/index.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8"/>
 <title>github.com/IrminData/irmin-sdk-go documentation</title>
 <h1>github.com/IrminData/irmin-sdk-go documentation</h1>
-<p>Generated on 2025-12-14 15:06 UTC</p>
+<p>Generated on 2025-12-18 08:07 UTC</p>
 <ul>
 <li><a href="github_com_IrminData_irmin-sdk-go.html">github.com/IrminData/irmin-sdk-go</a></li>
 <li><a href="github_com_IrminData_irmin-sdk-go_api.html">github.com/IrminData/irmin-sdk-go/api</a></li>

--- a/models/template.go
+++ b/models/template.go
@@ -17,11 +17,11 @@ const (
 // Template represents a template from which a script or query can be created.
 type Template struct {
 	ID           string           `json:"id"           validate:"required,validsqid=templates" example:"tpl_2k8n9q1m7p3x4z"`
-	Title        string           `json:"title"        validate:"required,max=100" example:"My Template"`
-	Description  string           `json:"description"  validate:"required,max=255" example:"This is a template for my application"`
-	Content      string           `json:"content"      validate:"required,max=10000" example:"This is the content of my template"`
-	Type         TemplateType     `json:"type"         validate:"required,max=50" example:"script"`
-	Language     TemplateLanguage `json:"language"     validate:"required,max=50" example:"go"`
-	Tags         []string         `json:"tags"         validate:"required,dive" example:"tag1,tag2,tag3"`
-	Placeholders []string         `json:"placeholders" validate:"omitempty,dive,max=100" example:"repository_slug,branch_name"`
+	Title        string           `json:"title"        validate:"required,max=100"             example:"My Template"`
+	Description  string           `json:"description"  validate:"required,max=255"             example:"This is a template for my application"`
+	Content      string           `json:"content"      validate:"required,max=10000"           example:"This is the content of my template"`
+	Type         TemplateType     `json:"type"         validate:"required,max=50"              example:"script"`
+	Language     TemplateLanguage `json:"language"     validate:"required,max=50"              example:"go"`
+	Tags         []string         `json:"tags"         validate:"required,dive"                example:"tag1,tag2,tag3"`
+	Placeholders []string         `json:"placeholders" validate:"omitempty,dive,max=100"       example:"repository_slug,branch_name"`
 }

--- a/models/template.go
+++ b/models/template.go
@@ -1,0 +1,26 @@
+package irminmodels
+
+type TemplateType string
+
+const (
+	TemplateTypeScript TemplateType = "script"
+	TemplateTypeQuery  TemplateType = "query"
+)
+
+type TemplateLanguage string
+
+const (
+	TemplateLanguageGo  TemplateLanguage = "go"
+	TemplateLanguageSQL TemplateLanguage = "sql"
+)
+
+// Template represents a template from which a script or query can be created.
+type Template struct {
+	ID          string           `json:"id"          validate:"required,validsqid=templates" example:"tpl_2k8n9q1m7p3x4z"`
+	Title       string           `json:"title"       validate:"required,max=100" example:"My Template"`
+	Description string           `json:"description" validate:"required,max=255" example:"This is a template for my application"`
+	Content     string           `json:"content"     validate:"required,max=10000" example:"This is the content of my template"`
+	Type        TemplateType     `json:"type"        validate:"required,max=50" example:"script"`
+	Language    TemplateLanguage `json:"language"    validate:"required,max=50" example:"go"`
+	Tags        []string         `json:"tags"        validate:"required,dive" example:"tag1,tag2,tag3"`
+}

--- a/models/template.go
+++ b/models/template.go
@@ -16,11 +16,12 @@ const (
 
 // Template represents a template from which a script or query can be created.
 type Template struct {
-	ID          string           `json:"id"          validate:"required,validsqid=templates" example:"tpl_2k8n9q1m7p3x4z"`
-	Title       string           `json:"title"       validate:"required,max=100" example:"My Template"`
-	Description string           `json:"description" validate:"required,max=255" example:"This is a template for my application"`
-	Content     string           `json:"content"     validate:"required,max=10000" example:"This is the content of my template"`
-	Type        TemplateType     `json:"type"        validate:"required,max=50" example:"script"`
-	Language    TemplateLanguage `json:"language"    validate:"required,max=50" example:"go"`
-	Tags        []string         `json:"tags"        validate:"required,dive" example:"tag1,tag2,tag3"`
+	ID           string           `json:"id"           validate:"required,validsqid=templates" example:"tpl_2k8n9q1m7p3x4z"`
+	Title        string           `json:"title"        validate:"required,max=100" example:"My Template"`
+	Description  string           `json:"description"  validate:"required,max=255" example:"This is a template for my application"`
+	Content      string           `json:"content"      validate:"required,max=10000" example:"This is the content of my template"`
+	Type         TemplateType     `json:"type"         validate:"required,max=50" example:"script"`
+	Language     TemplateLanguage `json:"language"     validate:"required,max=50" example:"go"`
+	Tags         []string         `json:"tags"         validate:"required,dive" example:"tag1,tag2,tag3"`
+	Placeholders []string         `json:"placeholders" validate:"omitempty,dive,max=100" example:"repository_slug,branch_name"`
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds client methods to list script and query templates and introduces a Template model with type/language enums.
> 
> - **API**:
>   - `api/queries.go`: Add `ListQueryTemplates` to fetch `/v1/workspaces/{workspace}/queries/templates`.
>   - `api/script.go`: Add `ListScriptTemplates` to fetch `/v1/workspaces/{workspace}/scripts/templates`.
> - **Models**:
>   - `models/template.go`: Introduce `Template` struct with `TemplateType` (`script`, `query`) and `TemplateLanguage` (`go`, `sql`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 734acb805c1306dff4d47958dbee5949767f21ae. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->