### PR TITLE
Tim/feat/pipeline validation stage

### DIFF
--- a/docs/docs.md
+++ b/docs/docs.md
@@ -3338,11 +3338,11 @@ type PatchOperation struct {
 
 ```go
 type PipelineStage struct {
-    Description   string            `json:"description"    validate:"required,max=200"                                                                                  example:"Process customer data"`
-    Write         bool              `json:"write"                                                                                                                       example:"true"`
-    Read          bool              `json:"read"                                                                                                                        example:"true"`
-    OrderSequence int               `json:"order_sequence"                                                                                                              example:"1"`
-    Type          PipelineStageType `json:"type"           validate:"required,oneof=action connection repository repository_action trigger_workflow,validpipelinestage" example:"repository"`
+    Description   string            `json:"description"    validate:"required,max=200"                                                                                             example:"Process customer data"`
+    Write         bool              `json:"write"                                                                                                                                  example:"true"`
+    Read          bool              `json:"read"                                                                                                                                   example:"true"`
+    OrderSequence int               `json:"order_sequence"                                                                                                                         example:"1"`
+    Type          PipelineStageType `json:"type"           validate:"required,oneof=action connection repository repository_action trigger_workflow validation,validpipelinestage" example:"repository"`
 
     // Action stage specific
     ExecutableType ActionExecutableType `json:"executable_type,omitempty" validate:"omitempty,oneof=script query,required_if=Type action"          example:"script"`
@@ -3373,6 +3373,12 @@ type PipelineStage struct {
 
     // Trigger Workflow stage specific
     TriggerWorkflowID *string `json:"trigger_workflow_id,omitempty" validate:"omitempty,validsqid=workflows,required_if=Type trigger_workflow" example:"wf_8x2m9k4n7p5q"`
+
+    // Validation stage specific
+    ValidationSchema     *ObjectSchema `json:"validation_schema,omitempty"`
+    ValidationMode       *string       `json:"validation_mode,omitempty"` // "single" or "all"
+    FailOnError          *bool         `json:"fail_on_error,omitempty"`
+    ValidationTargetName *string       `json:"validation_target_name,omitempty"`
 }
 ```
 
@@ -3394,6 +3400,7 @@ const (
     PipelineStageTypeRepository       PipelineStageType = "repository"
     PipelineStageTypeRepositoryAction PipelineStageType = "repository_action"
     PipelineStageTypeTriggerWorkflow  PipelineStageType = "trigger_workflow"
+    PipelineStageTypeValidation       PipelineStageType = "validation"
 )
 ```
 

--- a/docs/html/github_com_IrminData_irmin-sdk-go_models.html
+++ b/docs/html/github_com_IrminData_irmin-sdk-go_models.html
@@ -445,11 +445,11 @@ type PatchOperation struct {
     PatchOperation represents a single operation in a JSON Patch array.
 
 type PipelineStage struct {
-	Description   string            `json:"description"    validate:"required,max=200"                                                                                  example:"Process customer data"`
-	Write         bool              `json:"write"                                                                                                                       example:"true"`
-	Read          bool              `json:"read"                                                                                                                        example:"true"`
-	OrderSequence int               `json:"order_sequence"                                                                                                              example:"1"`
-	Type          PipelineStageType `json:"type"           validate:"required,oneof=action connection repository repository_action trigger_workflow,validpipelinestage" example:"repository"`
+	Description   string            `json:"description"    validate:"required,max=200"                                                                                             example:"Process customer data"`
+	Write         bool              `json:"write"                                                                                                                                  example:"true"`
+	Read          bool              `json:"read"                                                                                                                                   example:"true"`
+	OrderSequence int               `json:"order_sequence"                                                                                                                         example:"1"`
+	Type          PipelineStageType `json:"type"           validate:"required,oneof=action connection repository repository_action trigger_workflow validation,validpipelinestage" example:"repository"`
 
 	// Action stage specific
 	ExecutableType ActionExecutableType `json:"executable_type,omitempty" validate:"omitempty,oneof=script query,required_if=Type action"          example:"script"`
@@ -480,6 +480,12 @@ type PipelineStage struct {
 
 	// Trigger Workflow stage specific
 	TriggerWorkflowID *string `json:"trigger_workflow_id,omitempty" validate:"omitempty,validsqid=workflows,required_if=Type trigger_workflow" example:"wf_8x2m9k4n7p5q"`
+
+	// Validation stage specific
+	ValidationSchema     *ObjectSchema `json:"validation_schema,omitempty"`
+	ValidationMode       *string       `json:"validation_mode,omitempty"` // "single" or "all"
+	FailOnError          *bool         `json:"fail_on_error,omitempty"`
+	ValidationTargetName *string       `json:"validation_target_name,omitempty"`
 }
 
 type PipelineStageType string
@@ -490,6 +496,7 @@ const (
 	PipelineStageTypeRepository       PipelineStageType = "repository"
 	PipelineStageTypeRepositoryAction PipelineStageType = "repository_action"
 	PipelineStageTypeTriggerWorkflow  PipelineStageType = "trigger_workflow"
+	PipelineStageTypeValidation       PipelineStageType = "validation"
 )
 type Policy struct {
 	// ID is the unique identifier for the policy

--- a/docs/html/index.html
+++ b/docs/html/index.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8"/>
 <title>github.com/IrminData/irmin-sdk-go documentation</title>
 <h1>github.com/IrminData/irmin-sdk-go documentation</h1>
-<p>Generated on 2025-12-22 11:04 UTC</p>
+<p>Generated on 2025-12-23 11:31 UTC</p>
 <ul>
 <li><a href="github_com_IrminData_irmin-sdk-go.html">github.com/IrminData/irmin-sdk-go</a></li>
 <li><a href="github_com_IrminData_irmin-sdk-go_api.html">github.com/IrminData/irmin-sdk-go/api</a></li>

--- a/models/workflow.go
+++ b/models/workflow.go
@@ -37,6 +37,7 @@ const (
 	PipelineStageTypeRepository       PipelineStageType = "repository"
 	PipelineStageTypeRepositoryAction PipelineStageType = "repository_action"
 	PipelineStageTypeTriggerWorkflow  PipelineStageType = "trigger_workflow"
+	PipelineStageTypeValidation       PipelineStageType = "validation"
 )
 
 type RepositoryActionType string
@@ -48,11 +49,11 @@ const (
 )
 
 type PipelineStage struct {
-	Description   string            `json:"description"    validate:"required,max=200"                                                                                  example:"Process customer data"`
-	Write         bool              `json:"write"                                                                                                                       example:"true"`
-	Read          bool              `json:"read"                                                                                                                        example:"true"`
-	OrderSequence int               `json:"order_sequence"                                                                                                              example:"1"`
-	Type          PipelineStageType `json:"type"           validate:"required,oneof=action connection repository repository_action trigger_workflow,validpipelinestage" example:"repository"`
+	Description   string            `json:"description"    validate:"required,max=200"                                                                                             example:"Process customer data"`
+	Write         bool              `json:"write"                                                                                                                                  example:"true"`
+	Read          bool              `json:"read"                                                                                                                                   example:"true"`
+	OrderSequence int               `json:"order_sequence"                                                                                                                         example:"1"`
+	Type          PipelineStageType `json:"type"           validate:"required,oneof=action connection repository repository_action trigger_workflow validation,validpipelinestage" example:"repository"`
 
 	// Action stage specific
 	ExecutableType ActionExecutableType `json:"executable_type,omitempty" validate:"omitempty,oneof=script query,required_if=Type action"          example:"script"`
@@ -83,6 +84,12 @@ type PipelineStage struct {
 
 	// Trigger Workflow stage specific
 	TriggerWorkflowID *string `json:"trigger_workflow_id,omitempty" validate:"omitempty,validsqid=workflows,required_if=Type trigger_workflow" example:"wf_8x2m9k4n7p5q"`
+
+	// Validation stage specific
+	ValidationSchema     *ObjectSchema `json:"validation_schema,omitempty"`
+	ValidationMode       *string       `json:"validation_mode,omitempty"` // "single" or "all"
+	FailOnError          *bool         `json:"fail_on_error,omitempty"`
+	ValidationTargetName *string       `json:"validation_target_name,omitempty"`
 }
 
 type ActionInputData struct {

--- a/validator/domain_validators.go
+++ b/validator/domain_validators.go
@@ -81,6 +81,8 @@ func (v *Validator) validatePipelineStage(fl validator.FieldLevel) bool {
 		return v.validateRepositoryActionPipelineStage(parentStruct)
 	case "trigger_workflow":
 		return v.validateTriggerWorkflowPipelineStage(parentStruct)
+	case "validation":
+		return v.validateValidationPipelineStage(parentStruct)
 	default:
 		return true // Let oneof validation handle invalid types
 	}
@@ -236,6 +238,27 @@ func (v *Validator) validateTriggerWorkflowPipelineStage(parentStruct reflect.Va
 	// Trigger workflow stages must have a workflow ID (validated as SQID)
 	if !v.validateResourceID(triggerWorkflowIDField, "workflows") {
 		return false
+	}
+
+	return true
+}
+
+// validateValidationPipelineStage validates validation-type pipeline stages.
+func (v *Validator) validateValidationPipelineStage(parentStruct reflect.Value) bool {
+	validationSchemaField := parentStruct.FieldByName("ValidationSchema")
+	validationModeField := parentStruct.FieldByName("ValidationMode")
+
+	// ValidationSchema is required
+	if !validationSchemaField.IsValid() || validationSchemaField.IsNil() {
+		return false
+	}
+
+	// ValidationMode must be "single" or "all" if provided
+	if validationModeField.IsValid() && !validationModeField.IsNil() {
+		mode := validationModeField.Elem().String()
+		if mode != "single" && mode != "all" {
+			return false
+		}
 	}
 
 	return true


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds support for a new pipeline stage type focused on data validation.
> 
> - Extends `PipelineStageType` with `validation` and updates `PipelineStage.type` oneof to include it
> - Adds `PipelineStage` fields: `validation_schema`, `validation_mode` ("single"|"all"), `fail_on_error`, and `validation_target_name`
> - Updates validator to handle `validation` stages, requiring `validation_schema` and restricting `validation_mode` to "single" or "all"
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 86718e22f5a76a50f37604045f581caf57ac19b8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->