### PR TITLE
Tim/feat/ai app tool configs

### DIFF
--- a/api/ai-applications.go
+++ b/api/ai-applications.go
@@ -14,6 +14,7 @@ type CreateAIApplicationRequest struct {
 	Description    string                                `json:"description"     validate:"max=500"                       example:"AI application for customer data analysis"`
 	Documentation  string                                `json:"documentation"   validate:"validdocumentation"            example:"# Customer Analytics"`
 	AllowedOrigins []string                              `json:"allowed_origins" validate:"dive,max=255"                  example:"https://app.example.com,http://localhost:3000"`
+	Tools          *irminmodels.AIApplicationToolConfig  `json:"tools,omitempty"`
 	DataSources    []irminmodels.AIApplicationDataSource `json:"data_sources"    validate:"dive"`
 	Tags           []string                              `json:"tags,omitempty"  validate:"omitempty,dive,validsqid=tags" example:"tag_7k3m9x2n5q8p"`
 }
@@ -24,6 +25,7 @@ type UpdateAIApplicationRequest struct {
 	Description    *string                               `json:"description,omitempty"     validate:"omitempty,max=500"             example:"AI application for customer data analysis"`
 	Documentation  *string                               `json:"documentation,omitempty"   validate:"omitempty,validdocumentation"  example:"# Customer Analytics"`
 	AllowedOrigins []string                              `json:"allowed_origins,omitempty" validate:"omitempty,dive,max=255"`
+	Tools          *irminmodels.AIApplicationToolConfig  `json:"tools,omitempty"`
 	DataSources    []irminmodels.AIApplicationDataSource `json:"data_sources,omitempty"    validate:"omitempty,dive"`
 	Tags           []string                              `json:"tags,omitempty"            validate:"omitempty,dive,validsqid=tags"`
 }

--- a/docs/docs.md
+++ b/docs/docs.md
@@ -1833,6 +1833,7 @@ type CreateAIApplicationRequest struct {
     Description    string                                `json:"description"     validate:"max=500"                       example:"AI application for customer data analysis"`
     Documentation  string                                `json:"documentation"   validate:"validdocumentation"            example:"# Customer Analytics"`
     AllowedOrigins []string                              `json:"allowed_origins" validate:"dive,max=255"                  example:"https://app.example.com,http://localhost:3000"`
+    Tools          *irminmodels.AIApplicationToolConfig  `json:"tools,omitempty"`
     DataSources    []irminmodels.AIApplicationDataSource `json:"data_sources"    validate:"dive"`
     Tags           []string                              `json:"tags,omitempty"  validate:"omitempty,dive,validsqid=tags" example:"tag_7k3m9x2n5q8p"`
 }
@@ -2244,6 +2245,7 @@ type UpdateAIApplicationRequest struct {
     Description    *string                               `json:"description,omitempty"     validate:"omitempty,max=500"             example:"AI application for customer data analysis"`
     Documentation  *string                               `json:"documentation,omitempty"   validate:"omitempty,validdocumentation"  example:"# Customer Analytics"`
     AllowedOrigins []string                              `json:"allowed_origins,omitempty" validate:"omitempty,dive,max=255"`
+    Tools          *irminmodels.AIApplicationToolConfig  `json:"tools,omitempty"`
     DataSources    []irminmodels.AIApplicationDataSource `json:"data_sources,omitempty"    validate:"omitempty,dive"`
     Tags           []string                              `json:"tags,omitempty"            validate:"omitempty,dive,validsqid=tags"`
 }
@@ -2791,6 +2793,7 @@ import "github.com/IrminData/irmin-sdk-go/models"
 
 - [type AIApplication](<#AIApplication>)
 - [type AIApplicationDataSource](<#AIApplicationDataSource>)
+- [type AIApplicationToolConfig](<#AIApplicationToolConfig>)
 - [type APIToken](<#APIToken>)
 - [type ActionExecutableType](<#ActionExecutableType>)
 - [type ActionInputData](<#ActionInputData>)
@@ -2892,6 +2895,7 @@ type AIApplication struct {
     Description    string                    `json:"description"       validate:"max=500"                            example:"AI application for customer data analysis"`
     Documentation  string                    `json:"documentation"     validate:"validdocumentation"                 example:"# Customer Analytics"`
     AllowedOrigins []string                  `json:"allowed_origins"   validate:"dive,max=255"                       example:"https://app.example.com,http://localhost:3000"`
+    Tools          *AIApplicationToolConfig  `json:"tools,omitempty"`
     DataSources    []AIApplicationDataSource `json:"data_sources"      validate:"dive"`
     APIKey         *string                   `json:"api_key,omitempty"`
     Owner          User                      `json:"owner"             validate:"required"`
@@ -2911,6 +2915,22 @@ type AIApplicationDataSource struct {
     Repository string `json:"repository" validate:"required" example:"customer-analytics"`
     Branch     string `json:"branch"     validate:"required" example:"main"`
     Path       string `json:"path"       validate:"required" example:"/data/customers"`
+}
+```
+
+<a name="AIApplicationToolConfig"></a>
+## type AIApplicationToolConfig
+
+AIApplicationToolConfig defines which tools are enabled for an AI Application.
+
+```go
+type AIApplicationToolConfig struct {
+    QueryEnabled        bool `json:"query_enabled"         example:"true"`
+    SchemaEnabled       bool `json:"schema_enabled"        example:"true"`
+    ListObjectsEnabled  bool `json:"list_objects_enabled"  example:"true"`
+    GetContentEnabled   bool `json:"get_content_enabled"   example:"true"`
+    VectorSearchEnabled bool `json:"vector_search_enabled" example:"true"`
+    DocsEnabled         bool `json:"docs_enabled"          example:"true"`
 }
 ```
 

--- a/docs/html/github_com_IrminData_irmin-sdk-go_api.html
+++ b/docs/html/github_com_IrminData_irmin-sdk-go_api.html
@@ -939,6 +939,7 @@ type CreateAIApplicationRequest struct {
 	Description    string                                `json:"description"     validate:"max=500"                       example:"AI application for customer data analysis"`
 	Documentation  string                                `json:"documentation"   validate:"validdocumentation"            example:"# Customer Analytics"`
 	AllowedOrigins []string                              `json:"allowed_origins" validate:"dive,max=255"                  example:"https://app.example.com,http://localhost:3000"`
+	Tools          *irminmodels.AIApplicationToolConfig  `json:"tools,omitempty"`
 	DataSources    []irminmodels.AIApplicationDataSource `json:"data_sources"    validate:"dive"`
 	Tags           []string                              `json:"tags,omitempty"  validate:"omitempty,dive,validsqid=tags" example:"tag_7k3m9x2n5q8p"`
 }
@@ -1185,6 +1186,7 @@ type UpdateAIApplicationRequest struct {
 	Description    *string                               `json:"description,omitempty"     validate:"omitempty,max=500"             example:"AI application for customer data analysis"`
 	Documentation  *string                               `json:"documentation,omitempty"   validate:"omitempty,validdocumentation"  example:"# Customer Analytics"`
 	AllowedOrigins []string                              `json:"allowed_origins,omitempty" validate:"omitempty,dive,max=255"`
+	Tools          *irminmodels.AIApplicationToolConfig  `json:"tools,omitempty"`
 	DataSources    []irminmodels.AIApplicationDataSource `json:"data_sources,omitempty"    validate:"omitempty,dive"`
 	Tags           []string                              `json:"tags,omitempty"            validate:"omitempty,dive,validsqid=tags"`
 }

--- a/docs/html/github_com_IrminData_irmin-sdk-go_models.html
+++ b/docs/html/github_com_IrminData_irmin-sdk-go_models.html
@@ -13,6 +13,7 @@ type AIApplication struct {
 	Description    string                    `json:"description"       validate:"max=500"                            example:"AI application for customer data analysis"`
 	Documentation  string                    `json:"documentation"     validate:"validdocumentation"                 example:"# Customer Analytics"`
 	AllowedOrigins []string                  `json:"allowed_origins"   validate:"dive,max=255"                       example:"https://app.example.com,http://localhost:3000"`
+	Tools          *AIApplicationToolConfig  `json:"tools,omitempty"`
 	DataSources    []AIApplicationDataSource `json:"data_sources"      validate:"dive"`
 	APIKey         *string                   `json:"api_key,omitempty"`
 	Owner          User                      `json:"owner"             validate:"required"`
@@ -28,6 +29,17 @@ type AIApplicationDataSource struct {
 	Path       string `json:"path"       validate:"required" example:"/data/customers"`
 }
     AIApplicationDataSource represents a data source for an AI application.
+
+type AIApplicationToolConfig struct {
+	QueryEnabled        bool `json:"query_enabled"         example:"true"`
+	SchemaEnabled       bool `json:"schema_enabled"        example:"true"`
+	ListObjectsEnabled  bool `json:"list_objects_enabled"  example:"true"`
+	GetContentEnabled   bool `json:"get_content_enabled"   example:"true"`
+	VectorSearchEnabled bool `json:"vector_search_enabled" example:"true"`
+	DocsEnabled         bool `json:"docs_enabled"          example:"true"`
+}
+    AIApplicationToolConfig defines which tools are enabled for an AI
+    Application.
 
 type APIToken struct {
 	ID        string    `json:"id"              validate:"required,validsqid=api_tokens" example:"token_1a2b3c"`

--- a/docs/html/index.html
+++ b/docs/html/index.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8"/>
 <title>github.com/IrminData/irmin-sdk-go documentation</title>
 <h1>github.com/IrminData/irmin-sdk-go documentation</h1>
-<p>Generated on 2026-01-09 10:48 UTC</p>
+<p>Generated on 2026-01-09 13:32 UTC</p>
 <ul>
 <li><a href="github_com_IrminData_irmin-sdk-go.html">github.com/IrminData/irmin-sdk-go</a></li>
 <li><a href="github_com_IrminData_irmin-sdk-go_api.html">github.com/IrminData/irmin-sdk-go/api</a></li>

--- a/models/ai_application.go
+++ b/models/ai_application.go
@@ -9,6 +9,16 @@ type AIApplicationDataSource struct {
 	Path       string `json:"path"       validate:"required" example:"/data/customers"`
 }
 
+// AIApplicationToolConfig defines which tools are enabled for an AI Application.
+type AIApplicationToolConfig struct {
+	QueryEnabled        bool `json:"query_enabled"         example:"true"`
+	SchemaEnabled       bool `json:"schema_enabled"        example:"true"`
+	ListObjectsEnabled  bool `json:"list_objects_enabled"  example:"true"`
+	GetContentEnabled   bool `json:"get_content_enabled"   example:"true"`
+	VectorSearchEnabled bool `json:"vector_search_enabled" example:"true"`
+	DocsEnabled         bool `json:"docs_enabled"          example:"true"`
+}
+
 // AIApplication represents an AI application in the system.
 type AIApplication struct {
 	ID             string                    `json:"id"                validate:"required,validsqid=ai_applications" example:"ai_8x2m9k4n7p5q"`
@@ -16,6 +26,7 @@ type AIApplication struct {
 	Description    string                    `json:"description"       validate:"max=500"                            example:"AI application for customer data analysis"`
 	Documentation  string                    `json:"documentation"     validate:"validdocumentation"                 example:"# Customer Analytics"`
 	AllowedOrigins []string                  `json:"allowed_origins"   validate:"dive,max=255"                       example:"https://app.example.com,http://localhost:3000"`
+	Tools          *AIApplicationToolConfig  `json:"tools,omitempty"`
 	DataSources    []AIApplicationDataSource `json:"data_sources"      validate:"dive"`
 	APIKey         *string                   `json:"api_key,omitempty"`
 	Owner          User                      `json:"owner"             validate:"required"`


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds configurable tool flags to AI Applications and surfaces them through the API.
> 
> - New `AIApplicationToolConfig` model with booleans for `query`, `schema`, `list_objects`, `get_content`, `vector_search`, and `docs`
> - Add optional `tools` field to `AIApplication` and to `CreateAIApplicationRequest`/`UpdateAIApplicationRequest`
> - Regenerate docs (`docs.md`, HTML) reflecting the new model and fields
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b7ed42c257efebf9307b9db397920e5d4e971b6b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->