### PR TITLE
Tim/feat/ai app api

### DIFF
--- a/api/ai-app-client.go
+++ b/api/ai-app-client.go
@@ -37,7 +37,13 @@ func NewAIAppClient(baseURL, apiKey string) *AIAppClient {
 }
 
 // NewAIAppClientWithHTTPClient creates a new AI Application API client with a custom HTTP client.
+// If httpClient is nil, a default client with DefaultAPITimeout is used.
 func NewAIAppClientWithHTTPClient(baseURL, apiKey string, httpClient *http.Client) *AIAppClient {
+	if httpClient == nil {
+		httpClient = &http.Client{
+			Timeout: irminsdkgo.DefaultAPITimeout,
+		}
+	}
 	return &AIAppClient{
 		BaseURL:    baseURL,
 		APIKey:     apiKey,

--- a/api/ai-app-client.go
+++ b/api/ai-app-client.go
@@ -114,7 +114,11 @@ func (c *AIAppClient) Request(ctx context.Context, opts AIAppRequestOptions) ([]
 }
 
 // FetchAPI sends a request and attempts to parse the response into IrminAPIResponse.
-func (c *AIAppClient) FetchAPI(ctx context.Context, opts AIAppRequestOptions, out any) (*irminmodels.IrminAPIResponse, error) {
+func (c *AIAppClient) FetchAPI(
+	ctx context.Context,
+	opts AIAppRequestOptions,
+	out any,
+) (*irminmodels.IrminAPIResponse, error) {
 	body, err := c.Request(ctx, opts)
 	if err != nil {
 		return nil, err
@@ -130,12 +134,12 @@ func (c *AIAppClient) FetchAPI(ctx context.Context, opts AIAppRequestOptions, ou
 	}
 
 	if out != nil && apiResp.Data != nil {
-		dataBytes, err := json.Marshal(apiResp.Data)
-		if err != nil {
-			return nil, fmt.Errorf("failed to marshal Data field: %w", err)
+		dataBytes, marshalErr := json.Marshal(apiResp.Data)
+		if marshalErr != nil {
+			return nil, fmt.Errorf("failed to marshal Data field: %w", marshalErr)
 		}
-		if err = json.Unmarshal(dataBytes, out); err != nil {
-			return nil, fmt.Errorf("failed to unmarshal Data field: %w", err)
+		if unmarshalErr := json.Unmarshal(dataBytes, out); unmarshalErr != nil {
+			return nil, fmt.Errorf("failed to unmarshal Data field: %w", unmarshalErr)
 		}
 	}
 

--- a/api/ai-app-client.go
+++ b/api/ai-app-client.go
@@ -1,0 +1,143 @@
+package irmincore
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	irminsdkgo "github.com/IrminData/irmin-sdk-go"
+	irminmodels "github.com/IrminData/irmin-sdk-go/models"
+)
+
+// AIAppClient is a client for the AI Application API.
+// This client authenticates using an AI Application API key instead of a user token.
+type AIAppClient struct {
+	// BaseURL is your Irmin Core API base: e.g. "https://api.irmin.co/api"
+	BaseURL string
+
+	// APIKey is the AI Application API key (format: ai_xxx)
+	APIKey string
+
+	// HTTPClient is a customisable HTTP client. You can set timeouts, proxies, etc.
+	HTTPClient *http.Client
+}
+
+// NewAIAppClient creates a new AI Application API client.
+func NewAIAppClient(baseURL, apiKey string) *AIAppClient {
+	return &AIAppClient{
+		BaseURL: baseURL,
+		APIKey:  apiKey,
+		HTTPClient: &http.Client{
+			Timeout: irminsdkgo.DefaultAPITimeout,
+		},
+	}
+}
+
+// NewAIAppClientWithHTTPClient creates a new AI Application API client with a custom HTTP client.
+func NewAIAppClientWithHTTPClient(baseURL, apiKey string, httpClient *http.Client) *AIAppClient {
+	return &AIAppClient{
+		BaseURL:    baseURL,
+		APIKey:     apiKey,
+		HTTPClient: httpClient,
+	}
+}
+
+// AIAppRequestOptions allows you to specify how you'd like to send data in the request.
+type AIAppRequestOptions struct {
+	Method      string
+	Endpoint    string
+	Body        any               // For JSON, this can be a struct or map to JSON-encode
+	Headers     map[string]string // Extra headers, if needed
+	ContentType string            // e.g. "application/json"
+}
+
+// Request sends a request to the AI Application API and returns raw response data.
+func (c *AIAppClient) Request(ctx context.Context, opts AIAppRequestOptions) ([]byte, error) {
+	if ctx == nil {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(context.Background(), irminsdkgo.DefaultAPITimeout)
+		defer cancel()
+	}
+
+	url := fmt.Sprintf("%s%s", c.BaseURL, opts.Endpoint)
+
+	var bodyReader io.Reader
+	if opts.Body != nil {
+		jsonData, err := json.Marshal(opts.Body)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal JSON body: %w", err)
+		}
+		bodyReader = bytes.NewReader(jsonData)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, opts.Method, url, bodyReader)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	// Set authorization header with API key
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.APIKey))
+	req.Header.Set("Accept", "application/json")
+
+	if opts.Body != nil {
+		contentType := opts.ContentType
+		if contentType == "" {
+			contentType = "application/json"
+		}
+		req.Header.Set("Content-Type", contentType)
+	}
+
+	// Add any extra headers
+	for k, v := range opts.Headers {
+		req.Header.Set(k, v)
+	}
+
+	resp, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("request to %s failed: %w", url, err)
+	}
+	defer resp.Body.Close()
+
+	responseBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("API request failed with status %d. Body: %s", resp.StatusCode, responseBody)
+	}
+
+	return responseBody, nil
+}
+
+// FetchAPI sends a request and attempts to parse the response into IrminAPIResponse.
+func (c *AIAppClient) FetchAPI(ctx context.Context, opts AIAppRequestOptions, out any) (*irminmodels.IrminAPIResponse, error) {
+	body, err := c.Request(ctx, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	var apiResp irminmodels.IrminAPIResponse
+	if err = json.Unmarshal(body, &apiResp); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal response JSON: %w", err)
+	}
+
+	if len(apiResp.Errors) > 0 {
+		return &apiResp, fmt.Errorf("API errors: %v", apiResp.Errors)
+	}
+
+	if out != nil && apiResp.Data != nil {
+		dataBytes, err := json.Marshal(apiResp.Data)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal Data field: %w", err)
+		}
+		if err = json.Unmarshal(dataBytes, out); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal Data field: %w", err)
+		}
+	}
+
+	return &apiResp, nil
+}

--- a/api/ai-app.go
+++ b/api/ai-app.go
@@ -19,19 +19,19 @@ type AIAppQueryRequest struct {
 // AIAppSearchEmbeddingsRequest represents the request body for searching embeddings.
 type AIAppSearchEmbeddingsRequest struct {
 	Query  string            `json:"query"  validate:"required" example:"What is machine learning?"`
-	Path   string            `json:"path"   example:"/data-source/embeddings/docs.parquet"` // Optional: filter to specific embedding file
-	TopK   int               `json:"top_k"  example:"10"`                                   // Optional: defaults to 10
-	Filter map[string]string `json:"filter"`                                               // Optional: metadata filter
+	Path   string            `json:"path"                       example:"/data-source/embeddings/docs.parquet"` // Optional: filter to specific embedding file
+	TopK   int               `json:"top_k"                      example:"10"`                                   // Optional: defaults to 10
+	Filter map[string]string `json:"filter"`                                                                    // Optional: metadata filter
 }
 
 // === Response Types ===
 
 // AIAppInfo represents information about an AI Application.
 type AIAppInfo struct {
-	Name        string                              `json:"name"`
-	Description string                              `json:"description"`
-	Workspace   string                              `json:"workspace"`
-	Tools       irminmodels.AIApplicationToolConfig `json:"tools"`
+	Name        string                               `json:"name"`
+	Description string                               `json:"description"`
+	Workspace   string                               `json:"workspace"`
+	Tools       irminmodels.AIApplicationToolConfig  `json:"tools"`
 	DataSources []irminmodels.AIAppDataSourceUnified `json:"data_sources"`
 }
 

--- a/api/ai-app.go
+++ b/api/ai-app.go
@@ -1,0 +1,175 @@
+package irmincore
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	irminmodels "github.com/IrminData/irmin-sdk-go/models"
+)
+
+// === Request Types ===
+
+// AIAppQueryRequest represents the request body for executing SQL queries.
+type AIAppQueryRequest struct {
+	SQL string `json:"sql" validate:"required" example:"SELECT * FROM $['data-source;file.json'] LIMIT 10"`
+}
+
+// AIAppSearchEmbeddingsRequest represents the request body for searching embeddings.
+type AIAppSearchEmbeddingsRequest struct {
+	Query  string            `json:"query"  validate:"required" example:"What is machine learning?"`
+	Path   string            `json:"path"   example:"/data-source/embeddings/docs.parquet"` // Optional: filter to specific embedding file
+	TopK   int               `json:"top_k"  example:"10"`                                   // Optional: defaults to 10
+	Filter map[string]string `json:"filter"`                                               // Optional: metadata filter
+}
+
+// === Response Types ===
+
+// AIAppInfo represents information about an AI Application.
+type AIAppInfo struct {
+	Name        string                              `json:"name"`
+	Description string                              `json:"description"`
+	Workspace   string                              `json:"workspace"`
+	Tools       irminmodels.AIApplicationToolConfig `json:"tools"`
+	DataSources []irminmodels.AIAppDataSourceUnified `json:"data_sources"`
+}
+
+// AIAppContent represents the content of a data object.
+type AIAppContent struct {
+	Content       string `json:"content,omitempty"`        // Text content (for text/json files)
+	ContentBase64 string `json:"content_base64,omitempty"` // Base64 encoded content (for binary files)
+	MimeType      string `json:"mime_type"`
+}
+
+// AIAppSystemPrompt represents the system prompt response.
+type AIAppSystemPrompt struct {
+	SystemPrompt string `json:"system_prompt"`
+}
+
+// === API Methods ===
+
+// GetInfo retrieves information about the AI Application.
+func (c *AIAppClient) GetInfo(ctx context.Context) (*AIAppInfo, *irminmodels.IrminAPIResponse, error) {
+	var info AIAppInfo
+	apiResp, err := c.FetchAPI(ctx, AIAppRequestOptions{
+		Method:   http.MethodGet,
+		Endpoint: "/v1/ai-app/info",
+	}, &info)
+	if err != nil {
+		return nil, nil, fmt.Errorf("get AI app info error: %w", err)
+	}
+	return &info, apiResp, nil
+}
+
+// GetSystemPrompt retrieves the recommended system prompt for the AI Application.
+func (c *AIAppClient) GetSystemPrompt(ctx context.Context) (string, *irminmodels.IrminAPIResponse, error) {
+	var result AIAppSystemPrompt
+	apiResp, err := c.FetchAPI(ctx, AIAppRequestOptions{
+		Method:   http.MethodGet,
+		Endpoint: "/v1/ai-app/system-prompt",
+	}, &result)
+	if err != nil {
+		return "", nil, fmt.Errorf("get system prompt error: %w", err)
+	}
+	return result.SystemPrompt, apiResp, nil
+}
+
+// Query executes a SQL query within the AI Application's data scope.
+func (c *AIAppClient) Query(
+	ctx context.Context,
+	req AIAppQueryRequest,
+) (any, *irminmodels.IrminAPIResponse, error) {
+	var result any
+	apiResp, err := c.FetchAPI(ctx, AIAppRequestOptions{
+		Method:      http.MethodPost,
+		Endpoint:    "/v1/ai-app/query",
+		ContentType: "application/json",
+		Body:        req,
+	}, &result)
+	if err != nil {
+		return nil, nil, fmt.Errorf("query error: %w", err)
+	}
+	return result, apiResp, nil
+}
+
+// ListObjects lists objects at the specified path.
+// If path is empty, lists all data source roots.
+func (c *AIAppClient) ListObjects(
+	ctx context.Context,
+	path string,
+) (*irminmodels.Object, *irminmodels.IrminAPIResponse, error) {
+	var object irminmodels.Object
+
+	endpoint := "/v1/ai-app/objects"
+	if path != "" {
+		endpoint = fmt.Sprintf("%s?path=%s", endpoint, url.QueryEscape(path))
+	}
+
+	apiResp, err := c.FetchAPI(ctx, AIAppRequestOptions{
+		Method:   http.MethodGet,
+		Endpoint: endpoint,
+	}, &object)
+	if err != nil {
+		return nil, nil, fmt.Errorf("list objects error: %w", err)
+	}
+	return &object, apiResp, nil
+}
+
+// GetContent retrieves the content of an object at the specified path.
+func (c *AIAppClient) GetContent(
+	ctx context.Context,
+	path string,
+) (*AIAppContent, *irminmodels.IrminAPIResponse, error) {
+	var content AIAppContent
+
+	endpoint := fmt.Sprintf("/v1/ai-app/content?path=%s", url.QueryEscape(path))
+
+	apiResp, err := c.FetchAPI(ctx, AIAppRequestOptions{
+		Method:   http.MethodGet,
+		Endpoint: endpoint,
+	}, &content)
+	if err != nil {
+		return nil, nil, fmt.Errorf("get content error: %w", err)
+	}
+	return &content, apiResp, nil
+}
+
+// GetSchema retrieves the schema of an object at the specified path.
+func (c *AIAppClient) GetSchema(
+	ctx context.Context,
+	path string,
+) (*irminmodels.ObjectSchema, *irminmodels.IrminAPIResponse, error) {
+	var schema irminmodels.ObjectSchema
+
+	endpoint := fmt.Sprintf("/v1/ai-app/schema?path=%s", url.QueryEscape(path))
+
+	apiResp, err := c.FetchAPI(ctx, AIAppRequestOptions{
+		Method:   http.MethodGet,
+		Endpoint: endpoint,
+	}, &schema)
+	if err != nil {
+		return nil, nil, fmt.Errorf("get schema error: %w", err)
+	}
+	return &schema, apiResp, nil
+}
+
+// SearchEmbeddings performs vector similarity search.
+// If path is empty, searches across all embedding files in data sources.
+func (c *AIAppClient) SearchEmbeddings(
+	ctx context.Context,
+	req AIAppSearchEmbeddingsRequest,
+) (*irminmodels.EmbeddingSearchResponse, *irminmodels.IrminAPIResponse, error) {
+	var result irminmodels.EmbeddingSearchResponse
+
+	apiResp, err := c.FetchAPI(ctx, AIAppRequestOptions{
+		Method:      http.MethodPost,
+		Endpoint:    "/v1/ai-app/embeddings/search",
+		ContentType: "application/json",
+		Body:        req,
+	}, &result)
+	if err != nil {
+		return nil, nil, fmt.Errorf("search embeddings error: %w", err)
+	}
+	return &result, apiResp, nil
+}

--- a/api/ai-app.go
+++ b/api/ai-app.go
@@ -57,7 +57,7 @@ func (c *AIAppClient) GetInfo(ctx context.Context) (*AIAppInfo, *irminmodels.Irm
 		Endpoint: "/v1/ai-app/info",
 	}, &info)
 	if err != nil {
-		return nil, nil, fmt.Errorf("get AI app info error: %w", err)
+		return nil, apiResp, fmt.Errorf("get AI app info error: %w", err)
 	}
 	return &info, apiResp, nil
 }
@@ -70,7 +70,7 @@ func (c *AIAppClient) GetSystemPrompt(ctx context.Context) (string, *irminmodels
 		Endpoint: "/v1/ai-app/system-prompt",
 	}, &result)
 	if err != nil {
-		return "", nil, fmt.Errorf("get system prompt error: %w", err)
+		return "", apiResp, fmt.Errorf("get system prompt error: %w", err)
 	}
 	return result.SystemPrompt, apiResp, nil
 }
@@ -88,7 +88,7 @@ func (c *AIAppClient) Query(
 		Body:        req,
 	}, &result)
 	if err != nil {
-		return nil, nil, fmt.Errorf("query error: %w", err)
+		return nil, apiResp, fmt.Errorf("query error: %w", err)
 	}
 	return result, apiResp, nil
 }
@@ -111,7 +111,7 @@ func (c *AIAppClient) ListObjects(
 		Endpoint: endpoint,
 	}, &object)
 	if err != nil {
-		return nil, nil, fmt.Errorf("list objects error: %w", err)
+		return nil, apiResp, fmt.Errorf("list objects error: %w", err)
 	}
 	return &object, apiResp, nil
 }
@@ -130,7 +130,7 @@ func (c *AIAppClient) GetContent(
 		Endpoint: endpoint,
 	}, &content)
 	if err != nil {
-		return nil, nil, fmt.Errorf("get content error: %w", err)
+		return nil, apiResp, fmt.Errorf("get content error: %w", err)
 	}
 	return &content, apiResp, nil
 }
@@ -149,7 +149,7 @@ func (c *AIAppClient) GetSchema(
 		Endpoint: endpoint,
 	}, &schema)
 	if err != nil {
-		return nil, nil, fmt.Errorf("get schema error: %w", err)
+		return nil, apiResp, fmt.Errorf("get schema error: %w", err)
 	}
 	return &schema, apiResp, nil
 }
@@ -169,7 +169,7 @@ func (c *AIAppClient) SearchEmbeddings(
 		Body:        req,
 	}, &result)
 	if err != nil {
-		return nil, nil, fmt.Errorf("search embeddings error: %w", err)
+		return nil, apiResp, fmt.Errorf("search embeddings error: %w", err)
 	}
 	return &result, apiResp, nil
 }

--- a/docs/docs.md
+++ b/docs/docs.md
@@ -136,6 +136,24 @@ import "github.com/IrminData/irmin-sdk-go/api"
 ## Index
 
 - [func AddLimitResponseParam\(endpoint string\) string](<#AddLimitResponseParam>)
+- [type AIAppClient](<#AIAppClient>)
+  - [func NewAIAppClient\(baseURL, apiKey string\) \*AIAppClient](<#NewAIAppClient>)
+  - [func NewAIAppClientWithHTTPClient\(baseURL, apiKey string, httpClient \*http.Client\) \*AIAppClient](<#NewAIAppClientWithHTTPClient>)
+  - [func \(c \*AIAppClient\) FetchAPI\(ctx context.Context, opts AIAppRequestOptions, out any\) \(\*irminmodels.IrminAPIResponse, error\)](<#AIAppClient.FetchAPI>)
+  - [func \(c \*AIAppClient\) GetContent\(ctx context.Context, path string\) \(\*AIAppContent, \*irminmodels.IrminAPIResponse, error\)](<#AIAppClient.GetContent>)
+  - [func \(c \*AIAppClient\) GetInfo\(ctx context.Context\) \(\*AIAppInfo, \*irminmodels.IrminAPIResponse, error\)](<#AIAppClient.GetInfo>)
+  - [func \(c \*AIAppClient\) GetSchema\(ctx context.Context, path string\) \(\*irminmodels.ObjectSchema, \*irminmodels.IrminAPIResponse, error\)](<#AIAppClient.GetSchema>)
+  - [func \(c \*AIAppClient\) GetSystemPrompt\(ctx context.Context\) \(string, \*irminmodels.IrminAPIResponse, error\)](<#AIAppClient.GetSystemPrompt>)
+  - [func \(c \*AIAppClient\) ListObjects\(ctx context.Context, path string\) \(\*irminmodels.Object, \*irminmodels.IrminAPIResponse, error\)](<#AIAppClient.ListObjects>)
+  - [func \(c \*AIAppClient\) Query\(ctx context.Context, req AIAppQueryRequest\) \(any, \*irminmodels.IrminAPIResponse, error\)](<#AIAppClient.Query>)
+  - [func \(c \*AIAppClient\) Request\(ctx context.Context, opts AIAppRequestOptions\) \(\[\]byte, error\)](<#AIAppClient.Request>)
+  - [func \(c \*AIAppClient\) SearchEmbeddings\(ctx context.Context, req AIAppSearchEmbeddingsRequest\) \(\*irminmodels.EmbeddingSearchResponse, \*irminmodels.IrminAPIResponse, error\)](<#AIAppClient.SearchEmbeddings>)
+- [type AIAppContent](<#AIAppContent>)
+- [type AIAppInfo](<#AIAppInfo>)
+- [type AIAppQueryRequest](<#AIAppQueryRequest>)
+- [type AIAppRequestOptions](<#AIAppRequestOptions>)
+- [type AIAppSearchEmbeddingsRequest](<#AIAppSearchEmbeddingsRequest>)
+- [type AIAppSystemPrompt](<#AIAppSystemPrompt>)
 - [type Client](<#Client>)
   - [func NewClient\(baseURL, token, locale string\) \*Client](<#NewClient>)
   - [func NewClientWithSQIDManager\(baseURL, token, locale string, sqidManager \*irminsqids.SQIDManager\) \*Client](<#NewClientWithSQIDManager>)
@@ -356,6 +374,202 @@ func AddLimitResponseParam(endpoint string) string
 ```
 
 AddLimitResponseParam appends the limit\-response query parameter to an endpoint URL. It preserves the original query string format by using simple string concatenation to avoid re\-encoding or reordering existing parameters. Handles fragments correctly.
+
+<a name="AIAppClient"></a>
+## type AIAppClient
+
+AIAppClient is a client for the AI Application API. This client authenticates using an AI Application API key instead of a user token.
+
+```go
+type AIAppClient struct {
+    // BaseURL is your Irmin Core API base: e.g. "https://api.irmin.co/api"
+    BaseURL string
+
+    // APIKey is the AI Application API key (format: ai_xxx)
+    APIKey string
+
+    // HTTPClient is a customisable HTTP client. You can set timeouts, proxies, etc.
+    HTTPClient *http.Client
+}
+```
+
+<a name="NewAIAppClient"></a>
+### func NewAIAppClient
+
+```go
+func NewAIAppClient(baseURL, apiKey string) *AIAppClient
+```
+
+NewAIAppClient creates a new AI Application API client.
+
+<a name="NewAIAppClientWithHTTPClient"></a>
+### func NewAIAppClientWithHTTPClient
+
+```go
+func NewAIAppClientWithHTTPClient(baseURL, apiKey string, httpClient *http.Client) *AIAppClient
+```
+
+NewAIAppClientWithHTTPClient creates a new AI Application API client with a custom HTTP client.
+
+<a name="AIAppClient.FetchAPI"></a>
+### func \(\*AIAppClient\) FetchAPI
+
+```go
+func (c *AIAppClient) FetchAPI(ctx context.Context, opts AIAppRequestOptions, out any) (*irminmodels.IrminAPIResponse, error)
+```
+
+FetchAPI sends a request and attempts to parse the response into IrminAPIResponse.
+
+<a name="AIAppClient.GetContent"></a>
+### func \(\*AIAppClient\) GetContent
+
+```go
+func (c *AIAppClient) GetContent(ctx context.Context, path string) (*AIAppContent, *irminmodels.IrminAPIResponse, error)
+```
+
+GetContent retrieves the content of an object at the specified path.
+
+<a name="AIAppClient.GetInfo"></a>
+### func \(\*AIAppClient\) GetInfo
+
+```go
+func (c *AIAppClient) GetInfo(ctx context.Context) (*AIAppInfo, *irminmodels.IrminAPIResponse, error)
+```
+
+GetInfo retrieves information about the AI Application.
+
+<a name="AIAppClient.GetSchema"></a>
+### func \(\*AIAppClient\) GetSchema
+
+```go
+func (c *AIAppClient) GetSchema(ctx context.Context, path string) (*irminmodels.ObjectSchema, *irminmodels.IrminAPIResponse, error)
+```
+
+GetSchema retrieves the schema of an object at the specified path.
+
+<a name="AIAppClient.GetSystemPrompt"></a>
+### func \(\*AIAppClient\) GetSystemPrompt
+
+```go
+func (c *AIAppClient) GetSystemPrompt(ctx context.Context) (string, *irminmodels.IrminAPIResponse, error)
+```
+
+GetSystemPrompt retrieves the recommended system prompt for the AI Application.
+
+<a name="AIAppClient.ListObjects"></a>
+### func \(\*AIAppClient\) ListObjects
+
+```go
+func (c *AIAppClient) ListObjects(ctx context.Context, path string) (*irminmodels.Object, *irminmodels.IrminAPIResponse, error)
+```
+
+ListObjects lists objects at the specified path. If path is empty, lists all data source roots.
+
+<a name="AIAppClient.Query"></a>
+### func \(\*AIAppClient\) Query
+
+```go
+func (c *AIAppClient) Query(ctx context.Context, req AIAppQueryRequest) (any, *irminmodels.IrminAPIResponse, error)
+```
+
+Query executes a SQL query within the AI Application's data scope.
+
+<a name="AIAppClient.Request"></a>
+### func \(\*AIAppClient\) Request
+
+```go
+func (c *AIAppClient) Request(ctx context.Context, opts AIAppRequestOptions) ([]byte, error)
+```
+
+Request sends a request to the AI Application API and returns raw response data.
+
+<a name="AIAppClient.SearchEmbeddings"></a>
+### func \(\*AIAppClient\) SearchEmbeddings
+
+```go
+func (c *AIAppClient) SearchEmbeddings(ctx context.Context, req AIAppSearchEmbeddingsRequest) (*irminmodels.EmbeddingSearchResponse, *irminmodels.IrminAPIResponse, error)
+```
+
+SearchEmbeddings performs vector similarity search. If path is empty, searches across all embedding files in data sources.
+
+<a name="AIAppContent"></a>
+## type AIAppContent
+
+AIAppContent represents the content of a data object.
+
+```go
+type AIAppContent struct {
+    Content       string `json:"content,omitempty"`        // Text content (for text/json files)
+    ContentBase64 string `json:"content_base64,omitempty"` // Base64 encoded content (for binary files)
+    MimeType      string `json:"mime_type"`
+}
+```
+
+<a name="AIAppInfo"></a>
+## type AIAppInfo
+
+AIAppInfo represents information about an AI Application.
+
+```go
+type AIAppInfo struct {
+    Name        string                               `json:"name"`
+    Description string                               `json:"description"`
+    Workspace   string                               `json:"workspace"`
+    Tools       irminmodels.AIApplicationToolConfig  `json:"tools"`
+    DataSources []irminmodels.AIAppDataSourceUnified `json:"data_sources"`
+}
+```
+
+<a name="AIAppQueryRequest"></a>
+## type AIAppQueryRequest
+
+AIAppQueryRequest represents the request body for executing SQL queries.
+
+```go
+type AIAppQueryRequest struct {
+    SQL string `json:"sql" validate:"required" example:"SELECT * FROM $['data-source;file.json'] LIMIT 10"`
+}
+```
+
+<a name="AIAppRequestOptions"></a>
+## type AIAppRequestOptions
+
+AIAppRequestOptions allows you to specify how you'd like to send data in the request.
+
+```go
+type AIAppRequestOptions struct {
+    Method      string
+    Endpoint    string
+    Body        any               // For JSON, this can be a struct or map to JSON-encode
+    Headers     map[string]string // Extra headers, if needed
+    ContentType string            // e.g. "application/json"
+}
+```
+
+<a name="AIAppSearchEmbeddingsRequest"></a>
+## type AIAppSearchEmbeddingsRequest
+
+AIAppSearchEmbeddingsRequest represents the request body for searching embeddings.
+
+```go
+type AIAppSearchEmbeddingsRequest struct {
+    Query  string            `json:"query"  validate:"required" example:"What is machine learning?"`
+    Path   string            `json:"path"                       example:"/data-source/embeddings/docs.parquet"` // Optional: filter to specific embedding file
+    TopK   int               `json:"top_k"                      example:"10"`                                   // Optional: defaults to 10
+    Filter map[string]string `json:"filter"`                                                                    // Optional: metadata filter
+}
+```
+
+<a name="AIAppSystemPrompt"></a>
+## type AIAppSystemPrompt
+
+AIAppSystemPrompt represents the system prompt response.
+
+```go
+type AIAppSystemPrompt struct {
+    SystemPrompt string `json:"system_prompt"`
+}
+```
 
 <a name="Client"></a>
 ## type Client
@@ -2791,6 +3005,7 @@ import "github.com/IrminData/irmin-sdk-go/models"
 
 ## Index
 
+- [type AIAppDataSourceUnified](<#AIAppDataSourceUnified>)
 - [type AIApplication](<#AIApplication>)
 - [type AIApplicationDataSource](<#AIApplicationDataSource>)
 - [type AIApplicationToolConfig](<#AIApplicationToolConfig>)
@@ -2882,6 +3097,17 @@ import "github.com/IrminData/irmin-sdk-go/models"
 - [type Workspace](<#Workspace>)
 - [type WorkspaceSearchResultType](<#WorkspaceSearchResultType>)
 
+
+<a name="AIAppDataSourceUnified"></a>
+## type AIAppDataSourceUnified
+
+AIAppDataSourceUnified represents a data source with a unified path format. The unified path includes the repository slug as a prefix: /\{repository\-slug\}/\{path\}
+
+```go
+type AIAppDataSourceUnified struct {
+    Path string `json:"path" example:"/customer-analytics/data/customers"`
+}
+```
 
 <a name="AIApplication"></a>
 ## type AIApplication

--- a/docs/docs.md
+++ b/docs/docs.md
@@ -409,7 +409,7 @@ NewAIAppClient creates a new AI Application API client.
 func NewAIAppClientWithHTTPClient(baseURL, apiKey string, httpClient *http.Client) *AIAppClient
 ```
 
-NewAIAppClientWithHTTPClient creates a new AI Application API client with a custom HTTP client.
+NewAIAppClientWithHTTPClient creates a new AI Application API client with a custom HTTP client. If httpClient is nil, a default client with DefaultAPITimeout is used.
 
 <a name="AIAppClient.FetchAPI"></a>
 ### func \(\*AIAppClient\) FetchAPI

--- a/docs/html/github_com_IrminData_irmin-sdk-go_api.html
+++ b/docs/html/github_com_IrminData_irmin-sdk-go_api.html
@@ -33,8 +33,9 @@ func NewAIAppClient(baseURL, apiKey string) *AIAppClient
     NewAIAppClient creates a new AI Application API client.
 
 func NewAIAppClientWithHTTPClient(baseURL, apiKey string, httpClient *http.Client) *AIAppClient
-    NewAIAppClientWithHTTPClient creates a new AI Application API client with a
-    custom HTTP client.
+    NewAIAppClientWithHTTPClient creates a new AI Application API client
+    with a custom HTTP client. If httpClient is nil, a default client with
+    DefaultAPITimeout is used.
 
 func (c *AIAppClient) FetchAPI(
 	ctx context.Context,

--- a/docs/html/github_com_IrminData_irmin-sdk-go_api.html
+++ b/docs/html/github_com_IrminData_irmin-sdk-go_api.html
@@ -16,6 +16,122 @@ func AddLimitResponseParam(endpoint string) string
 
 TYPES
 
+type AIAppClient struct {
+	// BaseURL is your Irmin Core API base: e.g. "https://api.irmin.co/api"
+	BaseURL string
+
+	// APIKey is the AI Application API key (format: ai_xxx)
+	APIKey string
+
+	// HTTPClient is a customisable HTTP client. You can set timeouts, proxies, etc.
+	HTTPClient *http.Client
+}
+    AIAppClient is a client for the AI Application API. This client
+    authenticates using an AI Application API key instead of a user token.
+
+func NewAIAppClient(baseURL, apiKey string) *AIAppClient
+    NewAIAppClient creates a new AI Application API client.
+
+func NewAIAppClientWithHTTPClient(baseURL, apiKey string, httpClient *http.Client) *AIAppClient
+    NewAIAppClientWithHTTPClient creates a new AI Application API client with a
+    custom HTTP client.
+
+func (c *AIAppClient) FetchAPI(
+	ctx context.Context,
+	opts AIAppRequestOptions,
+	out any,
+) (*irminmodels.IrminAPIResponse, error)
+    FetchAPI sends a request and attempts to parse the response into
+    IrminAPIResponse.
+
+func (c *AIAppClient) GetContent(
+	ctx context.Context,
+	path string,
+) (*AIAppContent, *irminmodels.IrminAPIResponse, error)
+    GetContent retrieves the content of an object at the specified path.
+
+func (c *AIAppClient) GetInfo(ctx context.Context) (*AIAppInfo, *irminmodels.IrminAPIResponse, error)
+    GetInfo retrieves information about the AI Application.
+
+func (c *AIAppClient) GetSchema(
+	ctx context.Context,
+	path string,
+) (*irminmodels.ObjectSchema, *irminmodels.IrminAPIResponse, error)
+    GetSchema retrieves the schema of an object at the specified path.
+
+func (c *AIAppClient) GetSystemPrompt(ctx context.Context) (string, *irminmodels.IrminAPIResponse, error)
+    GetSystemPrompt retrieves the recommended system prompt for the AI
+    Application.
+
+func (c *AIAppClient) ListObjects(
+	ctx context.Context,
+	path string,
+) (*irminmodels.Object, *irminmodels.IrminAPIResponse, error)
+    ListObjects lists objects at the specified path. If path is empty, lists all
+    data source roots.
+
+func (c *AIAppClient) Query(
+	ctx context.Context,
+	req AIAppQueryRequest,
+) (any, *irminmodels.IrminAPIResponse, error)
+    Query executes a SQL query within the AI Application's data scope.
+
+func (c *AIAppClient) Request(ctx context.Context, opts AIAppRequestOptions) ([]byte, error)
+    Request sends a request to the AI Application API and returns raw response
+    data.
+
+func (c *AIAppClient) SearchEmbeddings(
+	ctx context.Context,
+	req AIAppSearchEmbeddingsRequest,
+) (*irminmodels.EmbeddingSearchResponse, *irminmodels.IrminAPIResponse, error)
+    SearchEmbeddings performs vector similarity search. If path is empty,
+    searches across all embedding files in data sources.
+
+type AIAppContent struct {
+	Content       string `json:"content,omitempty"`        // Text content (for text/json files)
+	ContentBase64 string `json:"content_base64,omitempty"` // Base64 encoded content (for binary files)
+	MimeType      string `json:"mime_type"`
+}
+    AIAppContent represents the content of a data object.
+
+type AIAppInfo struct {
+	Name        string                               `json:"name"`
+	Description string                               `json:"description"`
+	Workspace   string                               `json:"workspace"`
+	Tools       irminmodels.AIApplicationToolConfig  `json:"tools"`
+	DataSources []irminmodels.AIAppDataSourceUnified `json:"data_sources"`
+}
+    AIAppInfo represents information about an AI Application.
+
+type AIAppQueryRequest struct {
+	SQL string `json:"sql" validate:"required" example:"SELECT * FROM $['data-source;file.json'] LIMIT 10"`
+}
+    AIAppQueryRequest represents the request body for executing SQL queries.
+
+type AIAppRequestOptions struct {
+	Method      string
+	Endpoint    string
+	Body        any               // For JSON, this can be a struct or map to JSON-encode
+	Headers     map[string]string // Extra headers, if needed
+	ContentType string            // e.g. "application/json"
+}
+    AIAppRequestOptions allows you to specify how you'd like to send data in the
+    request.
+
+type AIAppSearchEmbeddingsRequest struct {
+	Query  string            `json:"query"  validate:"required" example:"What is machine learning?"`
+	Path   string            `json:"path"                       example:"/data-source/embeddings/docs.parquet"` // Optional: filter to specific embedding file
+	TopK   int               `json:"top_k"                      example:"10"`                                   // Optional: defaults to 10
+	Filter map[string]string `json:"filter"`                                                                    // Optional: metadata filter
+}
+    AIAppSearchEmbeddingsRequest represents the request body for searching
+    embeddings.
+
+type AIAppSystemPrompt struct {
+	SystemPrompt string `json:"system_prompt"`
+}
+    AIAppSystemPrompt represents the system prompt response.
+
 type Client struct {
 	// BaseURL is your Irmin Core API base: e.g. "https://api.irmin.co/api"
 	BaseURL string

--- a/docs/html/github_com_IrminData_irmin-sdk-go_models.html
+++ b/docs/html/github_com_IrminData_irmin-sdk-go_models.html
@@ -7,6 +7,13 @@ package irminmodels // import "github.com/IrminData/irmin-sdk-go/models"
 
 TYPES
 
+type AIAppDataSourceUnified struct {
+	Path string `json:"path" example:"/customer-analytics/data/customers"`
+}
+    AIAppDataSourceUnified represents a data source with a unified path
+    format. The unified path includes the repository slug as a prefix:
+    /{repository-slug}/{path}
+
 type AIApplication struct {
 	ID             string                    `json:"id"                validate:"required,validsqid=ai_applications" example:"ai_8x2m9k4n7p5q"`
 	Name           string                    `json:"name"              validate:"required,max=100"                   example:"Customer Analytics App"`

--- a/docs/html/index.html
+++ b/docs/html/index.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8"/>
 <title>github.com/IrminData/irmin-sdk-go documentation</title>
 <h1>github.com/IrminData/irmin-sdk-go documentation</h1>
-<p>Generated on 2026-01-11 15:27 UTC</p>
+<p>Generated on 2026-01-11 15:42 UTC</p>
 <ul>
 <li><a href="github_com_IrminData_irmin-sdk-go.html">github.com/IrminData/irmin-sdk-go</a></li>
 <li><a href="github_com_IrminData_irmin-sdk-go_api.html">github.com/IrminData/irmin-sdk-go/api</a></li>

--- a/docs/html/index.html
+++ b/docs/html/index.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8"/>
 <title>github.com/IrminData/irmin-sdk-go documentation</title>
 <h1>github.com/IrminData/irmin-sdk-go documentation</h1>
-<p>Generated on 2026-01-09 13:32 UTC</p>
+<p>Generated on 2026-01-11 15:27 UTC</p>
 <ul>
 <li><a href="github_com_IrminData_irmin-sdk-go.html">github.com/IrminData/irmin-sdk-go</a></li>
 <li><a href="github_com_IrminData_irmin-sdk-go_api.html">github.com/IrminData/irmin-sdk-go/api</a></li>

--- a/models/ai_application.go
+++ b/models/ai_application.go
@@ -9,6 +9,12 @@ type AIApplicationDataSource struct {
 	Path       string `json:"path"       validate:"required" example:"/data/customers"`
 }
 
+// AIAppDataSourceUnified represents a data source with a unified path format.
+// The unified path includes the repository slug as a prefix: /{repository-slug}/{path}
+type AIAppDataSourceUnified struct {
+	Path string `json:"path" example:"/customer-analytics/data/customers"`
+}
+
 // AIApplicationToolConfig defines which tools are enabled for an AI Application.
 type AIApplicationToolConfig struct {
 	QueryEnabled        bool `json:"query_enabled"         example:"true"`


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds an API-key–based client to access AI Application endpoints and updates SDK docs/models accordingly.
> 
> - New `AIAppClient` with request helpers (`Request`, `FetchAPI`) using `Authorization: Bearer ai_...`
> - Implements endpoints: `GetInfo`, `GetSystemPrompt`, `Query`, `ListObjects`, `GetContent`, `GetSchema`, `SearchEmbeddings`
> - Introduces request/response types (`AIAppRequestOptions`, `AIAppQueryRequest`, `AIAppSearchEmbeddingsRequest`, `AIAppContent`, `AIAppInfo`, `AIAppSystemPrompt`)
> - Adds `AIAppDataSourceUnified` to `models`
> - Updates generated docs (`docs.md`, HTML)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7f337a1b016d79d0b690f1c6801446ae6cd67f4c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->