### PR TITLE
Tim/feat/object pointers

### DIFF
--- a/api/repository-objects.go
+++ b/api/repository-objects.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"net/url"
 
 	irminmodels "github.com/IrminData/irmin-sdk-go/models"
 )
@@ -354,8 +355,8 @@ func (c *Client) CreatePointer(
 			"/v1/workspaces/%s/repositories/%s/objects/pointer?ref=%s&path=%s",
 			workspace,
 			repository,
-			ref,
-			path,
+			url.QueryEscape(ref),
+			url.QueryEscape(path),
 		),
 		ContentType: "application/json",
 		Body:        req,

--- a/api/repository-objects.go
+++ b/api/repository-objects.go
@@ -34,6 +34,19 @@ type ValidateObjectResponse struct {
 	Error string   `json:"error,omitempty"`
 }
 
+// CreatePointerRequest represents the JSON request body for creating pointer objects.
+type CreatePointerRequest struct {
+	// TargetWorkspace is the workspace containing the target object.
+	// Empty string means same workspace (reserved for future cross-workspace support).
+	TargetWorkspace string `json:"target_workspace,omitempty" validate:"omitempty,max=100" example:""`
+	// TargetRepository is the slug of the repository containing the target object.
+	TargetRepository string `json:"target_repository"          validate:"required,max=100"  example:"other-repo"`
+	// TargetPath is the path to the target object.
+	TargetPath string `json:"target_path"                validate:"required"          example:"data/customers.json"`
+	// TargetRef is the branch name or commit hash of the target object.
+	TargetRef string `json:"target_ref"                 validate:"required,max=100"  example:"main"`
+}
+
 // GetObjectAtPath fetches the object at the given path and ref.
 func (c *Client) GetObjectAtPath(
 	ctx context.Context,
@@ -325,4 +338,30 @@ func (c *Client) ValidateObject(
 		return nil, nil, fmt.Errorf("validate object error: %w", err)
 	}
 	return &response, apiResp, nil
+}
+
+// CreatePointer creates a pointer file that references an object in another repository.
+// The pointer path will be automatically prefixed with "_ptr." if not already.
+func (c *Client) CreatePointer(
+	ctx context.Context,
+	workspace, repository, path, ref string,
+	req CreatePointerRequest,
+) (*irminmodels.Object, *irminmodels.IrminAPIResponse, error) {
+	var object irminmodels.Object
+	apiResp, err := c.FetchAPI(ctx, RequestOptions{
+		Method: http.MethodPost,
+		Endpoint: fmt.Sprintf(
+			"/v1/workspaces/%s/repositories/%s/objects/pointer?ref=%s&path=%s",
+			workspace,
+			repository,
+			ref,
+			path,
+		),
+		ContentType: "application/json",
+		Body:        req,
+	}, &object)
+	if err != nil {
+		return nil, nil, fmt.Errorf("create pointer error: %w", err)
+	}
+	return &object, apiResp, nil
 }

--- a/docs/docs.md
+++ b/docs/docs.md
@@ -170,6 +170,7 @@ import "github.com/IrminData/irmin-sdk-go/api"
   - [func \(c \*Client\) CreateBranch\(ctx context.Context, workspace, repository string, req CreateBranchRequest\) \(\*irminmodels.Branch, \*irminmodels.IrminAPIResponse, error\)](<#Client.CreateBranch>)
   - [func \(c \*Client\) CreateCommit\(ctx context.Context, workspace, repository string, req CreateCommitRequest\) \(\*irminmodels.Commit, \*irminmodels.IrminAPIResponse, error\)](<#Client.CreateCommit>)
   - [func \(c \*Client\) CreateConnection\(ctx context.Context, workspace string, req CreateConnectionRequest\) \(\*irminmodels.Connection, \*irminmodels.IrminAPIResponse, error\)](<#Client.CreateConnection>)
+  - [func \(c \*Client\) CreatePointer\(ctx context.Context, workspace, repository, path, ref string, req CreatePointerRequest\) \(\*irminmodels.Object, \*irminmodels.IrminAPIResponse, error\)](<#Client.CreatePointer>)
   - [func \(c \*Client\) CreatePolicy\(ctx context.Context, workspace string, req CreatePolicyRequest\) \(\*irminmodels.Policy, \*irminmodels.IrminAPIResponse, error\)](<#Client.CreatePolicy>)
   - [func \(c \*Client\) CreateRepository\(ctx context.Context, workspace string, req CreateRepositoryRequest\) \(\*irminmodels.Repository, \*irminmodels.IrminAPIResponse, error\)](<#Client.CreateRepository>)
   - [func \(c \*Client\) CreateStoredQuery\(ctx context.Context, workspace string, req CreateQueryRequest\) \(\*irminmodels.StoredQuery, \*irminmodels.IrminAPIResponse, error\)](<#Client.CreateStoredQuery>)
@@ -322,6 +323,7 @@ import "github.com/IrminData/irmin-sdk-go/api"
 - [type CreateConnectionRequest](<#CreateConnectionRequest>)
 - [type CreateCredentialRequest](<#CreateCredentialRequest>)
 - [type CreateCustomToolRequest](<#CreateCustomToolRequest>)
+- [type CreatePointerRequest](<#CreatePointerRequest>)
 - [type CreatePolicyRequest](<#CreatePolicyRequest>)
 - [type CreateQueryRequest](<#CreateQueryRequest>)
 - [type CreateRepositoryRequest](<#CreateRepositoryRequest>)
@@ -739,6 +741,15 @@ func (c *Client) CreateConnection(ctx context.Context, workspace string, req Cre
 ```
 
 
+
+<a name="Client.CreatePointer"></a>
+### func \(\*Client\) CreatePointer
+
+```go
+func (c *Client) CreatePointer(ctx context.Context, workspace, repository, path, ref string, req CreatePointerRequest) (*irminmodels.Object, *irminmodels.IrminAPIResponse, error)
+```
+
+CreatePointer creates a pointer file that references an object in another repository. The pointer path will be automatically prefixed with "\_ptr." if not already.
 
 <a name="Client.CreatePolicy"></a>
 ### func \(\*Client\) CreatePolicy
@@ -2159,6 +2170,25 @@ type CreateCustomToolRequest struct {
 }
 ```
 
+<a name="CreatePointerRequest"></a>
+## type CreatePointerRequest
+
+CreatePointerRequest represents the JSON request body for creating pointer objects.
+
+```go
+type CreatePointerRequest struct {
+    // TargetWorkspace is the workspace containing the target object.
+    // Empty string means same workspace (reserved for future cross-workspace support).
+    TargetWorkspace string `json:"target_workspace,omitempty" validate:"omitempty,max=100" example:""`
+    // TargetRepository is the slug of the repository containing the target object.
+    TargetRepository string `json:"target_repository"          validate:"required,max=100"  example:"other-repo"`
+    // TargetPath is the path to the target object.
+    TargetPath string `json:"target_path"                validate:"required"          example:"data/customers.json"`
+    // TargetRef is the branch name or commit hash of the target object.
+    TargetRef string `json:"target_ref"                 validate:"required,max=100"  example:"main"`
+}
+```
+
 <a name="CreatePolicyRequest"></a>
 ## type CreatePolicyRequest
 
@@ -3185,6 +3215,7 @@ import "github.com/IrminData/irmin-sdk-go/models"
 - [type PatchOperation](<#PatchOperation>)
 - [type PipelineStage](<#PipelineStage>)
 - [type PipelineStageType](<#PipelineStageType>)
+- [type PointerTarget](<#PointerTarget>)
 - [type Policy](<#Policy>)
 - [type PolicyAction](<#PolicyAction>)
 - [type PolicyEffect](<#PolicyEffect>)
@@ -4060,6 +4091,10 @@ type Object struct {
     SQLSelector           string            `json:"sql_selector,omitempty"            validate:"omitempty"                              example:"$['workspace-slug;repository-slug;file.json@main']"`
     Tags                  []Tag             `json:"tags,omitempty"                    validate:"dive,omitempty"`
     Children              []Object          `json:"children,omitempty"                validate:"dive,omitempty"`
+    // IsPointer indicates if this object is a pointer to another object.
+    IsPointer bool `json:"is_pointer,omitempty"                                                                example:"false"`
+    // PointerTarget contains the target information if this object is a pointer.
+    PointerTarget *PointerTarget `json:"pointer_target,omitempty"          validate:"omitempty"`
 }
 ```
 
@@ -4253,6 +4288,24 @@ const (
     PipelineStageTypeTransform        PipelineStageType = "transform"
     PipelineStageTypeEmbeddings       PipelineStageType = "embeddings"
 )
+```
+
+<a name="PointerTarget"></a>
+## type PointerTarget
+
+PointerTarget represents the target of a pointer object.
+
+```go
+type PointerTarget struct {
+    // Workspace is the target workspace slug. Empty string means same workspace.
+    Workspace string `json:"target_workspace,omitempty" validate:"omitempty,max=100" example:""`
+    // Repository is the target repository slug.
+    Repository string `json:"target_repository"          validate:"required,max=100"  example:"other-repo"`
+    // Path is the path to the target object.
+    Path string `json:"target_path"                validate:"required"          example:"data/customers.json"`
+    // Ref is the target branch name or commit hash.
+    Ref string `json:"target_ref"                 validate:"required,max=100"  example:"main"`
+}
 ```
 
 <a name="Policy"></a>

--- a/docs/html/github_com_IrminData_irmin-sdk-go_api.html
+++ b/docs/html/github_com_IrminData_irmin-sdk-go_api.html
@@ -248,6 +248,15 @@ func (c *Client) CreateConnection(
 	req CreateConnectionRequest,
 ) (*irminmodels.Connection, *irminmodels.IrminAPIResponse, error)
 
+func (c *Client) CreatePointer(
+	ctx context.Context,
+	workspace, repository, path, ref string,
+	req CreatePointerRequest,
+) (*irminmodels.Object, *irminmodels.IrminAPIResponse, error)
+    CreatePointer creates a pointer file that references an object in another
+    repository. The pointer path will be automatically prefixed with "_ptr." if
+    not already.
+
 func (c *Client) CreatePolicy(
 	ctx context.Context,
 	workspace string,
@@ -1128,6 +1137,20 @@ type CreateCustomToolRequest struct {
 }
     CreateCustomToolRequest represents the request body for creating a custom
     tool.
+
+type CreatePointerRequest struct {
+	// TargetWorkspace is the workspace containing the target object.
+	// Empty string means same workspace (reserved for future cross-workspace support).
+	TargetWorkspace string `json:"target_workspace,omitempty" validate:"omitempty,max=100" example:""`
+	// TargetRepository is the slug of the repository containing the target object.
+	TargetRepository string `json:"target_repository"          validate:"required,max=100"  example:"other-repo"`
+	// TargetPath is the path to the target object.
+	TargetPath string `json:"target_path"                validate:"required"          example:"data/customers.json"`
+	// TargetRef is the branch name or commit hash of the target object.
+	TargetRef string `json:"target_ref"                 validate:"required,max=100"  example:"main"`
+}
+    CreatePointerRequest represents the JSON request body for creating pointer
+    objects.
 
 type CreatePolicyRequest struct {
 	Effect     irminmodels.PolicyEffect    `json:"effect"                validate:"required,oneof=allow deny"                                                                                                                                                                                                      example:"allow"`

--- a/docs/html/github_com_IrminData_irmin-sdk-go_models.html
+++ b/docs/html/github_com_IrminData_irmin-sdk-go_models.html
@@ -530,6 +530,10 @@ type Object struct {
 	SQLSelector           string            `json:"sql_selector,omitempty"            validate:"omitempty"                              example:"$['workspace-slug;repository-slug;file.json@main']"`
 	Tags                  []Tag             `json:"tags,omitempty"                    validate:"dive,omitempty"`
 	Children              []Object          `json:"children,omitempty"                validate:"dive,omitempty"`
+	// IsPointer indicates if this object is a pointer to another object.
+	IsPointer bool `json:"is_pointer,omitempty"                                                                example:"false"`
+	// PointerTarget contains the target information if this object is a pointer.
+	PointerTarget *PointerTarget `json:"pointer_target,omitempty"          validate:"omitempty"`
 }
 
 type ObjectSchema struct {
@@ -665,6 +669,18 @@ const (
 	PipelineStageTypeTransform        PipelineStageType = "transform"
 	PipelineStageTypeEmbeddings       PipelineStageType = "embeddings"
 )
+type PointerTarget struct {
+	// Workspace is the target workspace slug. Empty string means same workspace.
+	Workspace string `json:"target_workspace,omitempty" validate:"omitempty,max=100" example:""`
+	// Repository is the target repository slug.
+	Repository string `json:"target_repository"          validate:"required,max=100"  example:"other-repo"`
+	// Path is the path to the target object.
+	Path string `json:"target_path"                validate:"required"          example:"data/customers.json"`
+	// Ref is the target branch name or commit hash.
+	Ref string `json:"target_ref"                 validate:"required,max=100"  example:"main"`
+}
+    PointerTarget represents the target of a pointer object.
+
 type Policy struct {
 	// ID is the unique identifier for the policy
 	ID string `json:"id"                    validate:"required,validsqid=policies"                                                                                                                                                                                                            example:"pol_8x2m9k4n7p5q"`

--- a/docs/html/index.html
+++ b/docs/html/index.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8"/>
 <title>github.com/IrminData/irmin-sdk-go documentation</title>
 <h1>github.com/IrminData/irmin-sdk-go documentation</h1>
-<p>Generated on 2026-01-12 15:26 UTC</p>
+<p>Generated on 2026-01-12 22:31 UTC</p>
 <ul>
 <li><a href="github_com_IrminData_irmin-sdk-go.html">github.com/IrminData/irmin-sdk-go</a></li>
 <li><a href="github_com_IrminData_irmin-sdk-go_api.html">github.com/IrminData/irmin-sdk-go/api</a></li>

--- a/docs/html/index.html
+++ b/docs/html/index.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8"/>
 <title>github.com/IrminData/irmin-sdk-go documentation</title>
 <h1>github.com/IrminData/irmin-sdk-go documentation</h1>
-<p>Generated on 2026-01-12 22:31 UTC</p>
+<p>Generated on 2026-01-12 22:33 UTC</p>
 <ul>
 <li><a href="github_com_IrminData_irmin-sdk-go.html">github.com/IrminData/irmin-sdk-go</a></li>
 <li><a href="github_com_IrminData_irmin-sdk-go_api.html">github.com/IrminData/irmin-sdk-go/api</a></li>

--- a/models/object.go
+++ b/models/object.go
@@ -12,6 +12,18 @@ const (
 	ObjectTypeBinary ObjectType = "binary"
 )
 
+// PointerTarget represents the target of a pointer object.
+type PointerTarget struct {
+	// Workspace is the target workspace slug. Empty string means same workspace.
+	Workspace string `json:"target_workspace,omitempty" validate:"omitempty,max=100" example:""`
+	// Repository is the target repository slug.
+	Repository string `json:"target_repository"          validate:"required,max=100"  example:"other-repo"`
+	// Path is the path to the target object.
+	Path string `json:"target_path"                validate:"required"          example:"data/customers.json"`
+	// Ref is the target branch name or commit hash.
+	Ref string `json:"target_ref"                 validate:"required,max=100"  example:"main"`
+}
+
 type Object struct {
 	ID                    string            `json:"id"                                validate:"required,validsqid=repository_objects"  example:"obj_3x7k9m2n5q8p"`
 	Name                  string            `json:"name"                              validate:"omitempty,max=255"                      example:"customers.json"`                 // Empty name signifies root directory object
@@ -29,4 +41,8 @@ type Object struct {
 	SQLSelector           string            `json:"sql_selector,omitempty"            validate:"omitempty"                              example:"$['workspace-slug;repository-slug;file.json@main']"`
 	Tags                  []Tag             `json:"tags,omitempty"                    validate:"dive,omitempty"`
 	Children              []Object          `json:"children,omitempty"                validate:"dive,omitempty"`
+	// IsPointer indicates if this object is a pointer to another object.
+	IsPointer bool `json:"is_pointer,omitempty"                                                                example:"false"`
+	// PointerTarget contains the target information if this object is a pointer.
+	PointerTarget *PointerTarget `json:"pointer_target,omitempty"          validate:"omitempty"`
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds first-class support for repository object pointers.
> 
> - New `CreatePointerRequest` and `Client.CreatePointer` to POST `objects/pointer` for creating pointer files (auto `_ptr.` prefix noted)
> - Extends `models.Object` with `is_pointer` and `pointer_target` fields
> - Adds `PointerTarget` type to describe target workspace/repository/path/ref
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 51b892451ad33cf1d2d12ef1d93773495449dc42. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->