### PR TITLE
Tim/feat/connector patches

### DIFF
--- a/api/connection_subscriptions.go
+++ b/api/connection_subscriptions.go
@@ -4,15 +4,15 @@ package irmincore
 type CreateConnectionSubscriptionRequest struct {
 	Name        string   `json:"name"                   validate:"required,max=255"                       example:"CRM Lead Changes"`
 	Description string   `json:"description,omitempty"  validate:"max=1000"                               example:"Subscribe to lead changes in the CRM"`
-	FilterPaths []string `json:"filter_paths,omitempty" validate:"dive,max=500"                           example:"["leads", "contacts"]"`
-	EventTypes  []string `json:"event_types,omitempty"  validate:"dive,oneof=insert update delete upsert" example:"["insert", "update"]"`
+	FilterPaths []string `json:"filter_paths,omitempty" validate:"dive,max=500"                           example:"leads,contacts"`
+	EventTypes  []string `json:"event_types,omitempty"  validate:"dive,oneof=insert update delete upsert" example:"insert,update"`
 }
 
 // UpdateConnectionSubscriptionRequest represents the JSON request body for updating connection subscriptions.
 type UpdateConnectionSubscriptionRequest struct {
 	Name        *string   `json:"name,omitempty"         validate:"omitnil,max=255"                                example:"CRM Lead Changes"`
 	Description *string   `json:"description,omitempty"  validate:"omitnil,max=1000"                               example:"Subscribe to lead changes in the CRM"`
-	FilterPaths *[]string `json:"filter_paths,omitempty"                                                           example:"["leads", "contacts"]"`
-	EventTypes  *[]string `json:"event_types,omitempty"  validate:"omitnil,dive,oneof=insert update delete upsert" example:"["insert", "update"]"`
+	FilterPaths *[]string `json:"filter_paths,omitempty"                                                           example:"leads,contacts"`
+	EventTypes  *[]string `json:"event_types,omitempty"  validate:"omitnil,dive,oneof=insert update delete upsert" example:"insert,update"`
 	IsActive    *bool     `json:"is_active,omitempty"                                                              example:"true"`
 }

--- a/api/connection_subscriptions.go
+++ b/api/connection_subscriptions.go
@@ -4,15 +4,15 @@ package irmincore
 type CreateConnectionSubscriptionRequest struct {
 	Name        string   `json:"name"                   validate:"required,max=255"                       example:"CRM Lead Changes"`
 	Description string   `json:"description,omitempty"  validate:"max=1000"                               example:"Subscribe to lead changes in the CRM"`
-	FilterPaths []string `json:"filter_paths,omitempty" validate:"dive,max=500"                           example:"[\"leads\", \"contacts\"]"`
-	EventTypes  []string `json:"event_types,omitempty"  validate:"dive,oneof=insert update delete upsert" example:"[\"insert\", \"update\"]"`
+	FilterPaths []string `json:"filter_paths,omitempty" validate:"dive,max=500"                           example:"["leads", "contacts"]"`
+	EventTypes  []string `json:"event_types,omitempty"  validate:"dive,oneof=insert update delete upsert" example:"["insert", "update"]"`
 }
 
 // UpdateConnectionSubscriptionRequest represents the JSON request body for updating connection subscriptions.
 type UpdateConnectionSubscriptionRequest struct {
-	Name        *string   `json:"name,omitempty"         validate:"omitnil,max=255"                        example:"CRM Lead Changes"`
-	Description *string   `json:"description,omitempty"  validate:"omitnil,max=1000"                       example:"Subscribe to lead changes in the CRM"`
-	FilterPaths *[]string `json:"filter_paths,omitempty"                                                   example:"[\"leads\", \"contacts\"]"`
-	EventTypes  *[]string `json:"event_types,omitempty"  validate:"omitnil,dive,oneof=insert update delete upsert" example:"[\"insert\", \"update\"]"`
-	IsActive    *bool     `json:"is_active,omitempty"                                                      example:"true"`
+	Name        *string   `json:"name,omitempty"         validate:"omitnil,max=255"                                example:"CRM Lead Changes"`
+	Description *string   `json:"description,omitempty"  validate:"omitnil,max=1000"                               example:"Subscribe to lead changes in the CRM"`
+	FilterPaths *[]string `json:"filter_paths,omitempty"                                                           example:"["leads", "contacts"]"`
+	EventTypes  *[]string `json:"event_types,omitempty"  validate:"omitnil,dive,oneof=insert update delete upsert" example:"["insert", "update"]"`
+	IsActive    *bool     `json:"is_active,omitempty"                                                              example:"true"`
 }

--- a/api/connection_subscriptions.go
+++ b/api/connection_subscriptions.go
@@ -2,17 +2,17 @@ package irmincore
 
 // CreateConnectionSubscriptionRequest represents the JSON request body for creating connection subscriptions.
 type CreateConnectionSubscriptionRequest struct {
-	Name        string   `json:"name"                   validate:"required,max=255"                       example:"CRM Lead Changes"`
-	Description string   `json:"description,omitempty"  validate:"max=1000"                               example:"Subscribe to lead changes in the CRM"`
-	FilterPaths []string `json:"filter_paths,omitempty" validate:"dive,max=500"                           example:"leads,contacts"`
-	EventTypes  []string `json:"event_types,omitempty"  validate:"dive,oneof=insert update delete upsert" example:"insert,update"`
+	Name        string   `json:"name"                   validate:"required,max=255"                             example:"CRM Lead Changes"`
+	Description string   `json:"description,omitempty"  validate:"max=1000"                                     example:"Subscribe to lead changes in the CRM"`
+	FilterPaths []string `json:"filter_paths,omitempty" validate:"dive,max=500"                                 example:"leads,contacts"`
+	EventTypes  []string `json:"event_types,omitempty"  validate:"dive,oneof=insert update delete upsert batch" example:"insert,update"`
 }
 
 // UpdateConnectionSubscriptionRequest represents the JSON request body for updating connection subscriptions.
 type UpdateConnectionSubscriptionRequest struct {
-	Name        *string   `json:"name,omitempty"         validate:"omitnil,max=255"                                example:"CRM Lead Changes"`
-	Description *string   `json:"description,omitempty"  validate:"omitnil,max=1000"                               example:"Subscribe to lead changes in the CRM"`
-	FilterPaths *[]string `json:"filter_paths,omitempty"                                                           example:"leads,contacts"`
-	EventTypes  *[]string `json:"event_types,omitempty"  validate:"omitnil,dive,oneof=insert update delete upsert" example:"insert,update"`
-	IsActive    *bool     `json:"is_active,omitempty"                                                              example:"true"`
+	Name        *string   `json:"name,omitempty"         validate:"omitnil,max=255"                                      example:"CRM Lead Changes"`
+	Description *string   `json:"description,omitempty"  validate:"omitnil,max=1000"                                     example:"Subscribe to lead changes in the CRM"`
+	FilterPaths *[]string `json:"filter_paths,omitempty" validate:"omitnil,dive,max=500"                                 example:"leads,contacts"`
+	EventTypes  *[]string `json:"event_types,omitempty"  validate:"omitnil,dive,oneof=insert update delete upsert batch" example:"insert,update"`
+	IsActive    *bool     `json:"is_active,omitempty"                                                                    example:"true"`
 }

--- a/api/connection_subscriptions.go
+++ b/api/connection_subscriptions.go
@@ -1,0 +1,18 @@
+package irmincore
+
+// CreateConnectionSubscriptionRequest represents the JSON request body for creating connection subscriptions.
+type CreateConnectionSubscriptionRequest struct {
+	Name        string   `json:"name"                   validate:"required,max=255"                       example:"CRM Lead Changes"`
+	Description string   `json:"description,omitempty"  validate:"max=1000"                               example:"Subscribe to lead changes in the CRM"`
+	FilterPaths []string `json:"filter_paths,omitempty" validate:"dive,max=500"                           example:"[\"leads\", \"contacts\"]"`
+	EventTypes  []string `json:"event_types,omitempty"  validate:"dive,oneof=insert update delete upsert" example:"[\"insert\", \"update\"]"`
+}
+
+// UpdateConnectionSubscriptionRequest represents the JSON request body for updating connection subscriptions.
+type UpdateConnectionSubscriptionRequest struct {
+	Name        *string   `json:"name,omitempty"         validate:"omitnil,max=255"                        example:"CRM Lead Changes"`
+	Description *string   `json:"description,omitempty"  validate:"omitnil,max=1000"                       example:"Subscribe to lead changes in the CRM"`
+	FilterPaths *[]string `json:"filter_paths,omitempty"                                                   example:"[\"leads\", \"contacts\"]"`
+	EventTypes  *[]string `json:"event_types,omitempty"  validate:"omitnil,dive,oneof=insert update delete upsert" example:"[\"insert\", \"update\"]"`
+	IsActive    *bool     `json:"is_active,omitempty"                                                      example:"true"`
+}

--- a/docs/docs.md
+++ b/docs/docs.md
@@ -2229,8 +2229,8 @@ CreateConnectionSubscriptionRequest represents the JSON request body for creatin
 type CreateConnectionSubscriptionRequest struct {
     Name        string   `json:"name"                   validate:"required,max=255"                       example:"CRM Lead Changes"`
     Description string   `json:"description,omitempty"  validate:"max=1000"                               example:"Subscribe to lead changes in the CRM"`
-    FilterPaths []string `json:"filter_paths,omitempty" validate:"dive,max=500"                           example:"["leads", "contacts"]"`
-    EventTypes  []string `json:"event_types,omitempty"  validate:"dive,oneof=insert update delete upsert" example:"["insert", "update"]"`
+    FilterPaths []string `json:"filter_paths,omitempty" validate:"dive,max=500"                           example:"leads,contacts"`
+    EventTypes  []string `json:"event_types,omitempty"  validate:"dive,oneof=insert update delete upsert" example:"insert,update"`
 }
 ```
 
@@ -2771,8 +2771,8 @@ UpdateConnectionSubscriptionRequest represents the JSON request body for updatin
 type UpdateConnectionSubscriptionRequest struct {
     Name        *string   `json:"name,omitempty"         validate:"omitnil,max=255"                                example:"CRM Lead Changes"`
     Description *string   `json:"description,omitempty"  validate:"omitnil,max=1000"                               example:"Subscribe to lead changes in the CRM"`
-    FilterPaths *[]string `json:"filter_paths,omitempty"                                                           example:"["leads", "contacts"]"`
-    EventTypes  *[]string `json:"event_types,omitempty"  validate:"omitnil,dive,oneof=insert update delete upsert" example:"["insert", "update"]"`
+    FilterPaths *[]string `json:"filter_paths,omitempty"                                                           example:"leads,contacts"`
+    EventTypes  *[]string `json:"event_types,omitempty"  validate:"omitnil,dive,oneof=insert update delete upsert" example:"insert,update"`
     IsActive    *bool     `json:"is_active,omitempty"                                                              example:"true"`
 }
 ```
@@ -3824,8 +3824,8 @@ type ConnectionSubscription struct {
     Name         string   `json:"name"                   validate:"required,max=255"                            example:"CRM Lead Changes"`
     Description  string   `json:"description,omitempty"  validate:"max=1000"                                    example:"Subscribe to lead changes in the CRM"`
     ConnectionID string   `json:"connection_id"          validate:"required,validsqid=connections"              example:"conn_5p8q2n7m9x4k"`
-    FilterPaths  []string `json:"filter_paths,omitempty" validate:"dive,max=500"                                example:"["leads", "contacts"]"`
-    EventTypes   []string `json:"event_types,omitempty"  validate:"dive,oneof=insert update delete upsert"      example:"["insert", "update"]"`
+    FilterPaths  []string `json:"filter_paths,omitempty" validate:"dive,max=500"                                example:"leads,contacts"`
+    EventTypes   []string `json:"event_types,omitempty"  validate:"dive,oneof=insert update delete upsert"      example:"insert,update"`
     IsActive     bool     `json:"is_active"                                                                     example:"true"`
     WebhookURL   string   `json:"webhook_url,omitempty"  validate:"omitempty,url"                               example:"https://api.irmin.co/api/v1/webhooks/connectors/conn_123"`
     Owner        *User    `json:"owner,omitempty"`

--- a/docs/docs.md
+++ b/docs/docs.md
@@ -278,6 +278,7 @@ import "github.com/IrminData/irmin-sdk-go/api"
   - [func \(c \*Client\) RemoveUser\(ctx context.Context, workspace, userID string\) \(\*irminmodels.IrminAPIResponse, error\)](<#Client.RemoveUser>)
   - [func \(c \*Client\) Request\(ctx context.Context, opts RequestOptions\) \(\[\]byte, error\)](<#Client.Request>)
   - [func \(c \*Client\) ResendInvite\(ctx context.Context, inviteID string\) \(\*irminmodels.Invite, \*irminmodels.IrminAPIResponse, error\)](<#Client.ResendInvite>)
+  - [func \(c \*Client\) ResetBranch\(ctx context.Context, workspace, repository, branch string, req ResetBranchRequest\) \(\*irminmodels.IrminAPIResponse, error\)](<#Client.ResetBranch>)
   - [func \(c \*Client\) RevertChanges\(ctx context.Context, workspace, repository string, req RevertUncommittedChangesRequest\) \(\*irminmodels.IrminAPIResponse, error\)](<#Client.RevertChanges>)
   - [func \(c \*Client\) Search\(ctx context.Context, workspace string, params irminmodels.SearchFilters\) \(\*irminmodels.SearchResponse, \*irminmodels.IrminAPIResponse, error\)](<#Client.Search>)
   - [func \(c \*Client\) SearchEmbeddings\(ctx context.Context, workspace, repository string, req SearchEmbeddingsRequest\) \(\*irminmodels.EmbeddingSearchResponse, \*irminmodels.IrminAPIResponse, error\)](<#Client.SearchEmbeddings>)
@@ -349,6 +350,7 @@ import "github.com/IrminData/irmin-sdk-go/api"
 - [type MergeRefsRequest](<#MergeRefsRequest>)
 - [type MoveObjectRequest](<#MoveObjectRequest>)
 - [type RequestOptions](<#RequestOptions>)
+- [type ResetBranchRequest](<#ResetBranchRequest>)
 - [type RevertUncommittedChangesRequest](<#RevertUncommittedChangesRequest>)
 - [type SearchEmbeddingsRequest](<#SearchEmbeddingsRequest>)
 - [type SendInviteRequest](<#SendInviteRequest>)
@@ -1738,6 +1740,15 @@ func (c *Client) ResendInvite(ctx context.Context, inviteID string) (*irminmodel
 
 
 
+<a name="Client.ResetBranch"></a>
+### func \(\*Client\) ResetBranch
+
+```go
+func (c *Client) ResetBranch(ctx context.Context, workspace, repository, branch string, req ResetBranchRequest) (*irminmodels.IrminAPIResponse, error)
+```
+
+ResetBranch resets a branch to a specific commit reference. This performs a hard reset, moving the branch pointer to the specified commit. If force is true, uncommitted changes will be discarded.
+
 <a name="Client.RevertChanges"></a>
 ### func \(\*Client\) RevertChanges
 
@@ -2551,6 +2562,18 @@ type RequestOptions struct {
 }
 ```
 
+<a name="ResetBranchRequest"></a>
+## type ResetBranchRequest
+
+ResetBranchRequest represents the JSON request body for resetting a branch to a specific commit.
+
+```go
+type ResetBranchRequest struct {
+    CommitRef string `json:"commit_ref"      validate:"required" example:"abc123def456"`
+    Force     bool   `json:"force,omitempty"                     example:"false"`
+}
+```
+
 <a name="RevertUncommittedChangesRequest"></a>
 ## type RevertUncommittedChangesRequest
 
@@ -3324,6 +3347,7 @@ import "github.com/IrminData/irmin-sdk-go/models"
 - [type ChangeType](<#ChangeType>)
 - [type Commit](<#Commit>)
 - [type Connection](<#Connection>)
+- [type ConnectionEventType](<#ConnectionEventType>)
 - [type Connector](<#Connector>)
 - [type ConnectorCapability](<#ConnectorCapability>)
 - [type ConnectorCategory](<#ConnectorCategory>)
@@ -3359,6 +3383,7 @@ import "github.com/IrminData/irmin-sdk-go/models"
 - [type ObjectType](<#ObjectType>)
 - [type OutputFormat](<#OutputFormat>)
 - [type Patch](<#Patch>)
+- [type PatchDirection](<#PatchDirection>)
 - [type PatchOperation](<#PatchOperation>)
 - [type PipelineStage](<#PipelineStage>)
 - [type PipelineStageType](<#PipelineStageType>)
@@ -3733,6 +3758,26 @@ type Connection struct {
     Connector     Connector         `json:"connector"      validate:"required"`
     Tags          []Tag             `json:"tags,omitempty" validate:"dive"`
 }
+```
+
+<a name="ConnectionEventType"></a>
+## type ConnectionEventType
+
+ConnectionEventType represents the type of change event from a connector
+
+```go
+type ConnectionEventType string
+```
+
+<a name="ConnectionEventInsert"></a>
+
+```go
+const (
+    ConnectionEventInsert ConnectionEventType = "insert"
+    ConnectionEventUpdate ConnectionEventType = "update"
+    ConnectionEventDelete ConnectionEventType = "delete"
+    ConnectionEventBatch  ConnectionEventType = "batch"
+)
 ```
 
 <a name="Connector"></a>
@@ -4421,6 +4466,24 @@ Patch is a series of patch operations.
 type Patch []PatchOperation
 ```
 
+<a name="PatchDirection"></a>
+## type PatchDirection
+
+PatchDirection represents the direction of a patch operation.
+
+```go
+type PatchDirection string
+```
+
+<a name="PatchDirectionToConnection"></a>
+
+```go
+const (
+    PatchDirectionToConnection PatchDirection = "to_connection"
+    PatchDirectionToRepository PatchDirection = "to_repository"
+)
+```
+
 <a name="PatchOperation"></a>
 ## type PatchOperation
 
@@ -4429,13 +4492,16 @@ PatchOperation represents a single operation in a JSON Patch array.
 ```go
 type PatchOperation struct {
     // The operation: "add", "remove", "replace", "move" or "copy"
-    Op  string `json:"op"              validate:"required,oneof=add remove replace move copy" example:"replace"`
+    Op  string `json:"op"                     validate:"required,oneof=add remove replace move copy" example:"replace"`
     // The JSON-Pointer location to apply the operation
-    Path string `json:"path"            validate:"required"                                    example:"/users.json/1/name"`
+    Path string `json:"path"                   validate:"required"                                    example:"/users.json/1/name"`
     // Used for "move" or "copy" operations
-    From *string `json:"from,omitempty"  validate:"required_if=Op move,required_if=Op copy"     example:"/users.json/1/name"`
+    From *string `json:"from,omitempty"         validate:"required_if=Op move,required_if=Op copy"     example:"/users.json/1/name"`
     // Used for "add" or "replace" operations
-    Value *any `json:"value,omitempty" validate:"required_if=Op add,required_if=Op replace"   example:"John"`
+    Value *any `json:"value,omitempty"        validate:"required_if=Op add,required_if=Op replace"   example:"John"`
+    // ContentType indicates the MIME type for binary data.
+    // When set, Value should be base64-encoded binary content.
+    ContentType *string `json:"content_type,omitempty"                                                        example:"image/png"`
 }
 ```
 
@@ -4446,11 +4512,11 @@ type PatchOperation struct {
 
 ```go
 type PipelineStage struct {
-    Description   string            `json:"description"    validate:"required,max=200"                                                                                                                  example:"Process customer data"`
-    Write         bool              `json:"write"                                                                                                                                                       example:"true"`
-    Read          bool              `json:"read"                                                                                                                                                        example:"true"`
-    OrderSequence int               `json:"order_sequence"                                                                                                                                              example:"1"`
-    Type          PipelineStageType `json:"type"           validate:"required,oneof=action connection repository repository_action trigger_workflow validation transform embeddings,validpipelinestage" example:"repository"`
+    Description   string            `json:"description"    validate:"required,max=200"                                                                                                                        example:"Process customer data"`
+    Write         bool              `json:"write"                                                                                                                                                             example:"true"`
+    Read          bool              `json:"read"                                                                                                                                                              example:"true"`
+    OrderSequence int               `json:"order_sequence"                                                                                                                                                    example:"1"`
+    Type          PipelineStageType `json:"type"           validate:"required,oneof=action connection repository repository_action trigger_workflow validation transform embeddings patch,validpipelinestage" example:"repository"`
 
     // Action stage specific
     ExecutableType ActionExecutableType `json:"executable_type,omitempty" validate:"omitempty,oneof=script query,required_if=Type action"          example:"script"`
@@ -4511,6 +4577,13 @@ type PipelineStage struct {
     EmbeddingsQuery      *string                  `json:"embeddings_query,omitempty"       validate:"omitempty"                                                    example:"What is machine learning?"`
     EmbeddingsTopK       *int                     `json:"embeddings_top_k,omitempty"       validate:"omitempty,min=1"                                              example:"10"`
     EmbeddingsFilter     map[string]string        `json:"embeddings_filter,omitempty"      validate:"omitempty"`
+
+    // Patch stage specific
+    PatchDirection        *PatchDirection `json:"patch_direction,omitempty"         validate:"omitempty,oneof=to_connection to_repository,required_if=Type patch" example:"to_connection"`
+    PatchConnectionID     *string         `json:"patch_connection_id,omitempty"     validate:"omitempty,validsqid=connections"                                    example:"conn_8x2m9k4n7p5q"`
+    PatchRepository       *string         `json:"patch_repository,omitempty"        validate:"omitempty"                                                          example:"customer-analytics"`
+    PatchRepositoryBranch *string         `json:"patch_repository_branch,omitempty" validate:"omitempty"                                                          example:"main"`
+    PatchSourceFileName   *string         `json:"patch_source_file_name,omitempty"  validate:"omitempty"                                                          example:"patches.json"`
 }
 ```
 
@@ -4535,6 +4608,7 @@ const (
     PipelineStageTypeValidation       PipelineStageType = "validation"
     PipelineStageTypeTransform        PipelineStageType = "transform"
     PipelineStageTypeEmbeddings       PipelineStageType = "embeddings"
+    PipelineStageTypePatch            PipelineStageType = "patch"
 )
 ```
 
@@ -4890,20 +4964,26 @@ type Schedule struct {
 
 ```go
 type ScheduleTrigger struct {
-    Type WorkflowTriggerType `json:"type" validate:"required,oneof=time repository-event workflow-run-event,validschedule" example:"time"`
+    Type WorkflowTriggerType `json:"type" validate:"required,oneof=time repository-event workflow-run-event connection-event,validschedule" example:"time"`
 
     // Time trigger - these should only be validated if they have values
     RRule *string `json:"rrule,omitempty" example:"FREQ=DAILY;INTERVAL=1;BYHOUR=9"`
     Cron  *string `json:"cron,omitempty"  example:"0 9 * * *"`
 
     // Repository event trigger
-    RepositoryEvent *RepositoryEvent `json:"repository_event,omitempty" validate:"required_if=Type repository-event"       example:"post-commit"`
-    Repository      *string          `json:"repository,omitempty"       validate:"required_with=RepositoryEvent,validslug" example:"customer-analytics"` // Slug of the repository
-    RepositoryRef   *string          `json:"repository_ref,omitempty"   validate:"required_with=RepositoryEvent"           example:"main"`
+    RepositoryEvent    *RepositoryEvent `json:"repository_event,omitempty"      validate:"required_if=Type repository-event"       example:"post-commit"`
+    Repository         *string          `json:"repository,omitempty"            validate:"required_with=RepositoryEvent,validslug" example:"customer-analytics"` // Slug of the repository
+    RepositoryRef      *string          `json:"repository_ref,omitempty"        validate:"required_with=RepositoryEvent"           example:"main"`
+    IncludeDiffAsPatch *bool            `json:"include_diff_as_patch,omitempty"` // Generate patches from commit diff for export flows
 
     // Workflow run event trigger
     WorkflowRunEvent *WorkflowRunEvent `json:"workflow_run_event,omitempty" validate:"required_if=Type workflow-run-event"                example:"post-workflow-run"`
     WorkflowID       *string           `json:"workflow_id,omitempty"        validate:"required_with=WorkflowRunEvent,validsqid=workflows" example:"wf_8x2m9k4n7p5q"` // Sqid of the workflow
+
+    // Connection event trigger
+    ConnectionEventType  *ConnectionEventType `json:"connection_event_type,omitempty"`                                             // insert, update, delete, batch
+    ConnectionID         *string              `json:"connection_id,omitempty"          validate:"omitempty,validsqid=connections"` // Sqid of the connection
+    ConnectionEventPaths []string             `json:"connection_event_paths,omitempty"`                                            // Optional path filter (e.g., ["users", "orders"])
 }
 ```
 
@@ -5627,9 +5707,10 @@ type WorkflowTriggerType string
 
 ```go
 const (
-    TimeTriggerType        WorkflowTriggerType = "time"
-    RepositoryTriggerType  WorkflowTriggerType = "repository-event"
-    WorkflowRunTriggerType WorkflowTriggerType = "workflow-run-event"
+    TimeTriggerType            WorkflowTriggerType = "time"
+    RepositoryTriggerType      WorkflowTriggerType = "repository-event"
+    WorkflowRunTriggerType     WorkflowTriggerType = "workflow-run-event"
+    ConnectionEventTriggerType WorkflowTriggerType = "connection-event"
 )
 ```
 

--- a/docs/docs.md
+++ b/docs/docs.md
@@ -2227,10 +2227,10 @@ CreateConnectionSubscriptionRequest represents the JSON request body for creatin
 
 ```go
 type CreateConnectionSubscriptionRequest struct {
-    Name        string   `json:"name"                   validate:"required,max=255"                       example:"CRM Lead Changes"`
-    Description string   `json:"description,omitempty"  validate:"max=1000"                               example:"Subscribe to lead changes in the CRM"`
-    FilterPaths []string `json:"filter_paths,omitempty" validate:"dive,max=500"                           example:"leads,contacts"`
-    EventTypes  []string `json:"event_types,omitempty"  validate:"dive,oneof=insert update delete upsert" example:"insert,update"`
+    Name        string   `json:"name"                   validate:"required,max=255"                             example:"CRM Lead Changes"`
+    Description string   `json:"description,omitempty"  validate:"max=1000"                                     example:"Subscribe to lead changes in the CRM"`
+    FilterPaths []string `json:"filter_paths,omitempty" validate:"dive,max=500"                                 example:"leads,contacts"`
+    EventTypes  []string `json:"event_types,omitempty"  validate:"dive,oneof=insert update delete upsert batch" example:"insert,update"`
 }
 ```
 
@@ -2769,11 +2769,11 @@ UpdateConnectionSubscriptionRequest represents the JSON request body for updatin
 
 ```go
 type UpdateConnectionSubscriptionRequest struct {
-    Name        *string   `json:"name,omitempty"         validate:"omitnil,max=255"                                example:"CRM Lead Changes"`
-    Description *string   `json:"description,omitempty"  validate:"omitnil,max=1000"                               example:"Subscribe to lead changes in the CRM"`
-    FilterPaths *[]string `json:"filter_paths,omitempty"                                                           example:"leads,contacts"`
-    EventTypes  *[]string `json:"event_types,omitempty"  validate:"omitnil,dive,oneof=insert update delete upsert" example:"insert,update"`
-    IsActive    *bool     `json:"is_active,omitempty"                                                              example:"true"`
+    Name        *string   `json:"name,omitempty"         validate:"omitnil,max=255"                                      example:"CRM Lead Changes"`
+    Description *string   `json:"description,omitempty"  validate:"omitnil,max=1000"                                     example:"Subscribe to lead changes in the CRM"`
+    FilterPaths *[]string `json:"filter_paths,omitempty" validate:"omitnil,dive,max=500"                                 example:"leads,contacts"`
+    EventTypes  *[]string `json:"event_types,omitempty"  validate:"omitnil,dive,oneof=insert update delete upsert batch" example:"insert,update"`
+    IsActive    *bool     `json:"is_active,omitempty"                                                                    example:"true"`
 }
 ```
 
@@ -3809,6 +3809,7 @@ const (
     ConnectionEventInsert ConnectionEventType = "insert"
     ConnectionEventUpdate ConnectionEventType = "update"
     ConnectionEventDelete ConnectionEventType = "delete"
+    ConnectionEventUpsert ConnectionEventType = "upsert"
     ConnectionEventBatch  ConnectionEventType = "batch"
 )
 ```
@@ -3820,17 +3821,17 @@ ConnectionSubscription represents a subscription to data changes in a connection
 
 ```go
 type ConnectionSubscription struct {
-    ID           string   `json:"id"                     validate:"required,validsqid=connection_subscriptions" example:"cs_5p8q2n7m9x4k"`
-    Name         string   `json:"name"                   validate:"required,max=255"                            example:"CRM Lead Changes"`
-    Description  string   `json:"description,omitempty"  validate:"max=1000"                                    example:"Subscribe to lead changes in the CRM"`
-    ConnectionID string   `json:"connection_id"          validate:"required,validsqid=connections"              example:"conn_5p8q2n7m9x4k"`
-    FilterPaths  []string `json:"filter_paths,omitempty" validate:"dive,max=500"                                example:"leads,contacts"`
-    EventTypes   []string `json:"event_types,omitempty"  validate:"dive,oneof=insert update delete upsert"      example:"insert,update"`
-    IsActive     bool     `json:"is_active"                                                                     example:"true"`
-    WebhookURL   string   `json:"webhook_url,omitempty"  validate:"omitempty,url"                               example:"https://api.irmin.co/api/v1/webhooks/connectors/conn_123"`
+    ID           string   `json:"id"                     validate:"required,validsqid=connection_subscriptions"  example:"cs_5p8q2n7m9x4k"`
+    Name         string   `json:"name"                   validate:"required,max=255"                             example:"CRM Lead Changes"`
+    Description  string   `json:"description,omitempty"  validate:"max=1000"                                     example:"Subscribe to lead changes in the CRM"`
+    ConnectionID string   `json:"connection_id"          validate:"required,validsqid=connections"               example:"conn_5p8q2n7m9x4k"`
+    FilterPaths  []string `json:"filter_paths,omitempty" validate:"dive,max=500"                                 example:"leads,contacts"`
+    EventTypes   []string `json:"event_types,omitempty"  validate:"dive,oneof=insert update delete upsert batch" example:"insert,update"`
+    IsActive     bool     `json:"is_active"                                                                      example:"true"`
+    WebhookURL   string   `json:"webhook_url,omitempty"  validate:"omitempty,url"                                example:"https://api.irmin.co/api/v1/webhooks/connectors/conn_123"`
     Owner        *User    `json:"owner,omitempty"`
-    CreatedAt    string   `json:"created_at,omitempty"                                                          example:"2024-01-15T10:30:00Z"`
-    UpdatedAt    string   `json:"updated_at,omitempty"                                                          example:"2024-01-15T10:30:00Z"`
+    CreatedAt    string   `json:"created_at,omitempty"                                                           example:"2024-01-15T10:30:00Z"`
+    UpdatedAt    string   `json:"updated_at,omitempty"                                                           example:"2024-01-15T10:30:00Z"`
 }
 ```
 

--- a/docs/docs.md
+++ b/docs/docs.md
@@ -326,6 +326,7 @@ import "github.com/IrminData/irmin-sdk-go/api"
 - [type CreateBranchRequest](<#CreateBranchRequest>)
 - [type CreateCommitRequest](<#CreateCommitRequest>)
 - [type CreateConnectionRequest](<#CreateConnectionRequest>)
+- [type CreateConnectionSubscriptionRequest](<#CreateConnectionSubscriptionRequest>)
 - [type CreateCredentialRequest](<#CreateCredentialRequest>)
 - [type CreateCustomToolRequest](<#CreateCustomToolRequest>)
 - [type CreatePointerRequest](<#CreatePointerRequest>)
@@ -365,6 +366,7 @@ import "github.com/IrminData/irmin-sdk-go/api"
 - [type UpdateBranchRequest](<#UpdateBranchRequest>)
 - [type UpdateConnectionConfigurationRequest](<#UpdateConnectionConfigurationRequest>)
 - [type UpdateConnectionRequest](<#UpdateConnectionRequest>)
+- [type UpdateConnectionSubscriptionRequest](<#UpdateConnectionSubscriptionRequest>)
 - [type UpdateCustomToolRequest](<#UpdateCustomToolRequest>)
 - [type UpdateInviteRequest](<#UpdateInviteRequest>)
 - [type UpdatePolicyRequest](<#UpdatePolicyRequest>)
@@ -2218,6 +2220,20 @@ type CreateConnectionRequest struct {
 }
 ```
 
+<a name="CreateConnectionSubscriptionRequest"></a>
+## type CreateConnectionSubscriptionRequest
+
+CreateConnectionSubscriptionRequest represents the JSON request body for creating connection subscriptions.
+
+```go
+type CreateConnectionSubscriptionRequest struct {
+    Name        string   `json:"name"                   validate:"required,max=255"                       example:"CRM Lead Changes"`
+    Description string   `json:"description,omitempty"  validate:"max=1000"                               example:"Subscribe to lead changes in the CRM"`
+    FilterPaths []string `json:"filter_paths,omitempty" validate:"dive,max=500"                           example:"["leads", "contacts"]"`
+    EventTypes  []string `json:"event_types,omitempty"  validate:"dive,oneof=insert update delete upsert" example:"["insert", "update"]"`
+}
+```
+
 <a name="CreateCredentialRequest"></a>
 ## type CreateCredentialRequest
 
@@ -2743,6 +2759,21 @@ type UpdateConnectionRequest struct {
     Name          *string `json:"name,omitempty"          validate:"omitnil,max=100"            example:"Production MySQL Database"`
     Description   *string `json:"description,omitempty"   validate:"omitnil,max=500"            example:"Primary MySQL database for production customer data"`
     Documentation *string `json:"documentation,omitempty" validate:"omitnil,validdocumentation" example:"# Production Database"`
+}
+```
+
+<a name="UpdateConnectionSubscriptionRequest"></a>
+## type UpdateConnectionSubscriptionRequest
+
+UpdateConnectionSubscriptionRequest represents the JSON request body for updating connection subscriptions.
+
+```go
+type UpdateConnectionSubscriptionRequest struct {
+    Name        *string   `json:"name,omitempty"         validate:"omitnil,max=255"                                example:"CRM Lead Changes"`
+    Description *string   `json:"description,omitempty"  validate:"omitnil,max=1000"                               example:"Subscribe to lead changes in the CRM"`
+    FilterPaths *[]string `json:"filter_paths,omitempty"                                                           example:"["leads", "contacts"]"`
+    EventTypes  *[]string `json:"event_types,omitempty"  validate:"omitnil,dive,oneof=insert update delete upsert" example:"["insert", "update"]"`
+    IsActive    *bool     `json:"is_active,omitempty"                                                              example:"true"`
 }
 ```
 
@@ -3348,6 +3379,8 @@ import "github.com/IrminData/irmin-sdk-go/models"
 - [type Commit](<#Commit>)
 - [type Connection](<#Connection>)
 - [type ConnectionEventType](<#ConnectionEventType>)
+- [type ConnectionSubscription](<#ConnectionSubscription>)
+- [type ConnectionSubscriptionWithToken](<#ConnectionSubscriptionWithToken>)
 - [type Connector](<#Connector>)
 - [type ConnectorCapability](<#ConnectorCapability>)
 - [type ConnectorCategory](<#ConnectorCategory>)
@@ -3780,6 +3813,39 @@ const (
 )
 ```
 
+<a name="ConnectionSubscription"></a>
+## type ConnectionSubscription
+
+ConnectionSubscription represents a subscription to data changes in a connection. When data changes in the external system, the connector sends webhook events to the Irmin API using the WebhookToken for authentication.
+
+```go
+type ConnectionSubscription struct {
+    ID           string   `json:"id"                     validate:"required,validsqid=connection_subscriptions" example:"cs_5p8q2n7m9x4k"`
+    Name         string   `json:"name"                   validate:"required,max=255"                            example:"CRM Lead Changes"`
+    Description  string   `json:"description,omitempty"  validate:"max=1000"                                    example:"Subscribe to lead changes in the CRM"`
+    ConnectionID string   `json:"connection_id"          validate:"required,validsqid=connections"              example:"conn_5p8q2n7m9x4k"`
+    FilterPaths  []string `json:"filter_paths,omitempty" validate:"dive,max=500"                                example:"["leads", "contacts"]"`
+    EventTypes   []string `json:"event_types,omitempty"  validate:"dive,oneof=insert update delete upsert"      example:"["insert", "update"]"`
+    IsActive     bool     `json:"is_active"                                                                     example:"true"`
+    WebhookURL   string   `json:"webhook_url,omitempty"  validate:"omitempty,url"                               example:"https://api.irmin.co/api/v1/webhooks/connectors/conn_123"`
+    Owner        *User    `json:"owner,omitempty"`
+    CreatedAt    string   `json:"created_at,omitempty"                                                          example:"2024-01-15T10:30:00Z"`
+    UpdatedAt    string   `json:"updated_at,omitempty"                                                          example:"2024-01-15T10:30:00Z"`
+}
+```
+
+<a name="ConnectionSubscriptionWithToken"></a>
+## type ConnectionSubscriptionWithToken
+
+ConnectionSubscriptionWithToken includes the webhook token \(only returned on creation\).
+
+```go
+type ConnectionSubscriptionWithToken struct {
+    ConnectionSubscription
+    WebhookToken string `json:"webhook_token,omitempty" example:"abc123def456..."`
+}
+```
+
 <a name="Connector"></a>
 ## type Connector
 
@@ -3802,7 +3868,7 @@ type Connector struct {
     // URL to the connector's logo
     LogoURL string `json:"logo_url"          validate:"required,validimageurl"                                                                                                                                         example:"https://cdn.irmin.dev/mysql.png"`
     // Array of capabilities of the connector, eg. what kind of operations the connector can perform
-    Capabilities []ConnectorCapability `json:"capabilities"      validate:"required,dive,oneof=pull push push_patch event_webhook"                                                                                                         example:"pull,push"`
+    Capabilities []ConnectorCapability `json:"capabilities"      validate:"required,dive,oneof=pull push apply_patch patch_event"                                                                                                          example:"pull,push"`
     // Array of locales supported by the connector, eg. what languages the connector supports
     Locales []string `json:"locales"           validate:"required,dive,min=2,max=5"                                                                                                                                      example:"en,fi"`
     // Array of categories associated with the connector, eg. what kind of connector it is
@@ -3833,10 +3899,13 @@ const (
     ConnectorCapabilityPull ConnectorCapability = "pull"
     // ConnectorCapabilityPush means that data files can be pushed to different paths in the connector.
     ConnectorCapabilityPush ConnectorCapability = "push"
-    // ConnectorCapabilityPushPatch means that JSON Patch based change sets can be pushed to the connector.
-    ConnectorCapabilityPushPatch ConnectorCapability = "push_patch"
-    // ConnectorCapabilityEventWebhook means that the connector can send webhook notifications when something changes in the underlying data.
-    ConnectorCapabilityEventWebhook ConnectorCapability = "event_webhook"
+    // ConnectorCapabilityApplyPatch means that the connector can receive and apply patch operations.
+    // Patches follow JSON Patch format (RFC 6902) and can include binary data when the target
+    // data type requires it (e.g., images, files). Binary data is base64-encoded with content_type set.
+    ConnectorCapabilityApplyPatch ConnectorCapability = "apply_patch"
+    // ConnectorCapabilityPatchEvent means that the connector can emit patch events via webhooks
+    // when data changes in the external system. Changes are always expressed as patches.
+    ConnectorCapabilityPatchEvent ConnectorCapability = "patch_event"
 )
 ```
 

--- a/docs/html/github_com_IrminData_irmin-sdk-go_api.html
+++ b/docs/html/github_com_IrminData_irmin-sdk-go_api.html
@@ -1183,6 +1183,15 @@ type CreateConnectionRequest struct {
     CreateConnectionRequest represents the JSON request body for creating
     connections.
 
+type CreateConnectionSubscriptionRequest struct {
+	Name        string   `json:"name"                   validate:"required,max=255"                       example:"CRM Lead Changes"`
+	Description string   `json:"description,omitempty"  validate:"max=1000"                               example:"Subscribe to lead changes in the CRM"`
+	FilterPaths []string `json:"filter_paths,omitempty" validate:"dive,max=500"                           example:"["leads", "contacts"]"`
+	EventTypes  []string `json:"event_types,omitempty"  validate:"dive,oneof=insert update delete upsert" example:"["insert", "update"]"`
+}
+    CreateConnectionSubscriptionRequest represents the JSON request body for
+    creating connection subscriptions.
+
 type CreateCredentialRequest struct {
 	Name   string `json:"name"   validate:"required,max=100" example:"API Token"`
 	Expiry int    `json:"expiry" validate:"required"         example:"3600"` // Seconds until expiry
@@ -1503,6 +1512,16 @@ type UpdateConnectionRequest struct {
 }
     UpdateConnectionRequest represents the JSON request body for updating
     connections.
+
+type UpdateConnectionSubscriptionRequest struct {
+	Name        *string   `json:"name,omitempty"         validate:"omitnil,max=255"                                example:"CRM Lead Changes"`
+	Description *string   `json:"description,omitempty"  validate:"omitnil,max=1000"                               example:"Subscribe to lead changes in the CRM"`
+	FilterPaths *[]string `json:"filter_paths,omitempty"                                                           example:"["leads", "contacts"]"`
+	EventTypes  *[]string `json:"event_types,omitempty"  validate:"omitnil,dive,oneof=insert update delete upsert" example:"["insert", "update"]"`
+	IsActive    *bool     `json:"is_active,omitempty"                                                              example:"true"`
+}
+    UpdateConnectionSubscriptionRequest represents the JSON request body for
+    updating connection subscriptions.
 
 type UpdateCustomToolRequest struct {
 	ID          *string                    `json:"id,omitempty" validate:"omitempty,validsqid=ai_application_custom_tools"`

--- a/docs/html/github_com_IrminData_irmin-sdk-go_api.html
+++ b/docs/html/github_com_IrminData_irmin-sdk-go_api.html
@@ -855,6 +855,15 @@ func (c *Client) ResendInvite(
 	inviteID string,
 ) (*irminmodels.Invite, *irminmodels.IrminAPIResponse, error)
 
+func (c *Client) ResetBranch(
+	ctx context.Context,
+	workspace, repository, branch string,
+	req ResetBranchRequest,
+) (*irminmodels.IrminAPIResponse, error)
+    ResetBranch resets a branch to a specific commit reference. This performs a
+    hard reset, moving the branch pointer to the specified commit. If force is
+    true, uncommitted changes will be discarded.
+
 func (c *Client) RevertChanges(
 	ctx context.Context,
 	workspace, repository string,
@@ -1387,6 +1396,13 @@ type RequestOptions struct {
 }
     RequestOptions allows you to specify how you'd like to send data in the
     request.
+
+type ResetBranchRequest struct {
+	CommitRef string `json:"commit_ref"      validate:"required" example:"abc123def456"`
+	Force     bool   `json:"force,omitempty"                     example:"false"`
+}
+    ResetBranchRequest represents the JSON request body for resetting a branch
+    to a specific commit.
 
 type RevertUncommittedChangesRequest struct {
 	Branch   string `json:"branch"              validate:"required" example:"main"`

--- a/docs/html/github_com_IrminData_irmin-sdk-go_api.html
+++ b/docs/html/github_com_IrminData_irmin-sdk-go_api.html
@@ -1186,8 +1186,8 @@ type CreateConnectionRequest struct {
 type CreateConnectionSubscriptionRequest struct {
 	Name        string   `json:"name"                   validate:"required,max=255"                       example:"CRM Lead Changes"`
 	Description string   `json:"description,omitempty"  validate:"max=1000"                               example:"Subscribe to lead changes in the CRM"`
-	FilterPaths []string `json:"filter_paths,omitempty" validate:"dive,max=500"                           example:"["leads", "contacts"]"`
-	EventTypes  []string `json:"event_types,omitempty"  validate:"dive,oneof=insert update delete upsert" example:"["insert", "update"]"`
+	FilterPaths []string `json:"filter_paths,omitempty" validate:"dive,max=500"                           example:"leads,contacts"`
+	EventTypes  []string `json:"event_types,omitempty"  validate:"dive,oneof=insert update delete upsert" example:"insert,update"`
 }
     CreateConnectionSubscriptionRequest represents the JSON request body for
     creating connection subscriptions.
@@ -1516,8 +1516,8 @@ type UpdateConnectionRequest struct {
 type UpdateConnectionSubscriptionRequest struct {
 	Name        *string   `json:"name,omitempty"         validate:"omitnil,max=255"                                example:"CRM Lead Changes"`
 	Description *string   `json:"description,omitempty"  validate:"omitnil,max=1000"                               example:"Subscribe to lead changes in the CRM"`
-	FilterPaths *[]string `json:"filter_paths,omitempty"                                                           example:"["leads", "contacts"]"`
-	EventTypes  *[]string `json:"event_types,omitempty"  validate:"omitnil,dive,oneof=insert update delete upsert" example:"["insert", "update"]"`
+	FilterPaths *[]string `json:"filter_paths,omitempty"                                                           example:"leads,contacts"`
+	EventTypes  *[]string `json:"event_types,omitempty"  validate:"omitnil,dive,oneof=insert update delete upsert" example:"insert,update"`
 	IsActive    *bool     `json:"is_active,omitempty"                                                              example:"true"`
 }
     UpdateConnectionSubscriptionRequest represents the JSON request body for

--- a/docs/html/github_com_IrminData_irmin-sdk-go_api.html
+++ b/docs/html/github_com_IrminData_irmin-sdk-go_api.html
@@ -1184,10 +1184,10 @@ type CreateConnectionRequest struct {
     connections.
 
 type CreateConnectionSubscriptionRequest struct {
-	Name        string   `json:"name"                   validate:"required,max=255"                       example:"CRM Lead Changes"`
-	Description string   `json:"description,omitempty"  validate:"max=1000"                               example:"Subscribe to lead changes in the CRM"`
-	FilterPaths []string `json:"filter_paths,omitempty" validate:"dive,max=500"                           example:"leads,contacts"`
-	EventTypes  []string `json:"event_types,omitempty"  validate:"dive,oneof=insert update delete upsert" example:"insert,update"`
+	Name        string   `json:"name"                   validate:"required,max=255"                             example:"CRM Lead Changes"`
+	Description string   `json:"description,omitempty"  validate:"max=1000"                                     example:"Subscribe to lead changes in the CRM"`
+	FilterPaths []string `json:"filter_paths,omitempty" validate:"dive,max=500"                                 example:"leads,contacts"`
+	EventTypes  []string `json:"event_types,omitempty"  validate:"dive,oneof=insert update delete upsert batch" example:"insert,update"`
 }
     CreateConnectionSubscriptionRequest represents the JSON request body for
     creating connection subscriptions.
@@ -1514,11 +1514,11 @@ type UpdateConnectionRequest struct {
     connections.
 
 type UpdateConnectionSubscriptionRequest struct {
-	Name        *string   `json:"name,omitempty"         validate:"omitnil,max=255"                                example:"CRM Lead Changes"`
-	Description *string   `json:"description,omitempty"  validate:"omitnil,max=1000"                               example:"Subscribe to lead changes in the CRM"`
-	FilterPaths *[]string `json:"filter_paths,omitempty"                                                           example:"leads,contacts"`
-	EventTypes  *[]string `json:"event_types,omitempty"  validate:"omitnil,dive,oneof=insert update delete upsert" example:"insert,update"`
-	IsActive    *bool     `json:"is_active,omitempty"                                                              example:"true"`
+	Name        *string   `json:"name,omitempty"         validate:"omitnil,max=255"                                      example:"CRM Lead Changes"`
+	Description *string   `json:"description,omitempty"  validate:"omitnil,max=1000"                                     example:"Subscribe to lead changes in the CRM"`
+	FilterPaths *[]string `json:"filter_paths,omitempty" validate:"omitnil,dive,max=500"                                 example:"leads,contacts"`
+	EventTypes  *[]string `json:"event_types,omitempty"  validate:"omitnil,dive,oneof=insert update delete upsert batch" example:"insert,update"`
+	IsActive    *bool     `json:"is_active,omitempty"                                                                    example:"true"`
 }
     UpdateConnectionSubscriptionRequest represents the JSON request body for
     updating connection subscriptions.

--- a/docs/html/github_com_IrminData_irmin-sdk-go_models.html
+++ b/docs/html/github_com_IrminData_irmin-sdk-go_models.html
@@ -200,6 +200,15 @@ type Connection struct {
 	Tags          []Tag             `json:"tags,omitempty" validate:"dive"`
 }
 
+type ConnectionEventType string
+    ConnectionEventType represents the type of change event from a connector
+
+const (
+	ConnectionEventInsert ConnectionEventType = "insert"
+	ConnectionEventUpdate ConnectionEventType = "update"
+	ConnectionEventDelete ConnectionEventType = "delete"
+	ConnectionEventBatch  ConnectionEventType = "batch"
+)
 type Connector struct {
 	// ID is a unique SQIDidentifier of the connector
 	ID string `json:"id"                validate:"required,validsqid=connectors"                                                                                                                                  example:"conn_9m3x7k2n8q5p"`
@@ -630,24 +639,34 @@ const (
 type Patch []PatchOperation
     Patch is a series of patch operations.
 
+type PatchDirection string
+    PatchDirection represents the direction of a patch operation.
+
+const (
+	PatchDirectionToConnection PatchDirection = "to_connection"
+	PatchDirectionToRepository PatchDirection = "to_repository"
+)
 type PatchOperation struct {
 	// The operation: "add", "remove", "replace", "move" or "copy"
-	Op string `json:"op"              validate:"required,oneof=add remove replace move copy" example:"replace"`
+	Op string `json:"op"                     validate:"required,oneof=add remove replace move copy" example:"replace"`
 	// The JSON-Pointer location to apply the operation
-	Path string `json:"path"            validate:"required"                                    example:"/users.json/1/name"`
+	Path string `json:"path"                   validate:"required"                                    example:"/users.json/1/name"`
 	// Used for "move" or "copy" operations
-	From *string `json:"from,omitempty"  validate:"required_if=Op move,required_if=Op copy"     example:"/users.json/1/name"`
+	From *string `json:"from,omitempty"         validate:"required_if=Op move,required_if=Op copy"     example:"/users.json/1/name"`
 	// Used for "add" or "replace" operations
-	Value *any `json:"value,omitempty" validate:"required_if=Op add,required_if=Op replace"   example:"John"`
+	Value *any `json:"value,omitempty"        validate:"required_if=Op add,required_if=Op replace"   example:"John"`
+	// ContentType indicates the MIME type for binary data.
+	// When set, Value should be base64-encoded binary content.
+	ContentType *string `json:"content_type,omitempty"                                                        example:"image/png"`
 }
     PatchOperation represents a single operation in a JSON Patch array.
 
 type PipelineStage struct {
-	Description   string            `json:"description"    validate:"required,max=200"                                                                                                                  example:"Process customer data"`
-	Write         bool              `json:"write"                                                                                                                                                       example:"true"`
-	Read          bool              `json:"read"                                                                                                                                                        example:"true"`
-	OrderSequence int               `json:"order_sequence"                                                                                                                                              example:"1"`
-	Type          PipelineStageType `json:"type"           validate:"required,oneof=action connection repository repository_action trigger_workflow validation transform embeddings,validpipelinestage" example:"repository"`
+	Description   string            `json:"description"    validate:"required,max=200"                                                                                                                        example:"Process customer data"`
+	Write         bool              `json:"write"                                                                                                                                                             example:"true"`
+	Read          bool              `json:"read"                                                                                                                                                              example:"true"`
+	OrderSequence int               `json:"order_sequence"                                                                                                                                                    example:"1"`
+	Type          PipelineStageType `json:"type"           validate:"required,oneof=action connection repository repository_action trigger_workflow validation transform embeddings patch,validpipelinestage" example:"repository"`
 
 	// Action stage specific
 	ExecutableType ActionExecutableType `json:"executable_type,omitempty" validate:"omitempty,oneof=script query,required_if=Type action"          example:"script"`
@@ -708,6 +727,13 @@ type PipelineStage struct {
 	EmbeddingsQuery      *string                  `json:"embeddings_query,omitempty"       validate:"omitempty"                                                    example:"What is machine learning?"`
 	EmbeddingsTopK       *int                     `json:"embeddings_top_k,omitempty"       validate:"omitempty,min=1"                                              example:"10"`
 	EmbeddingsFilter     map[string]string        `json:"embeddings_filter,omitempty"      validate:"omitempty"`
+
+	// Patch stage specific
+	PatchDirection        *PatchDirection `json:"patch_direction,omitempty"         validate:"omitempty,oneof=to_connection to_repository,required_if=Type patch" example:"to_connection"`
+	PatchConnectionID     *string         `json:"patch_connection_id,omitempty"     validate:"omitempty,validsqid=connections"                                    example:"conn_8x2m9k4n7p5q"`
+	PatchRepository       *string         `json:"patch_repository,omitempty"        validate:"omitempty"                                                          example:"customer-analytics"`
+	PatchRepositoryBranch *string         `json:"patch_repository_branch,omitempty" validate:"omitempty"                                                          example:"main"`
+	PatchSourceFileName   *string         `json:"patch_source_file_name,omitempty"  validate:"omitempty"                                                          example:"patches.json"`
 }
 
 type PipelineStageType string
@@ -721,6 +747,7 @@ const (
 	PipelineStageTypeValidation       PipelineStageType = "validation"
 	PipelineStageTypeTransform        PipelineStageType = "transform"
 	PipelineStageTypeEmbeddings       PipelineStageType = "embeddings"
+	PipelineStageTypePatch            PipelineStageType = "patch"
 )
 type PointerTarget struct {
 	// Workspace is the target workspace slug. Empty string means same workspace.
@@ -943,20 +970,26 @@ type Schedule struct {
 }
 
 type ScheduleTrigger struct {
-	Type WorkflowTriggerType `json:"type" validate:"required,oneof=time repository-event workflow-run-event,validschedule" example:"time"`
+	Type WorkflowTriggerType `json:"type" validate:"required,oneof=time repository-event workflow-run-event connection-event,validschedule" example:"time"`
 
 	// Time trigger - these should only be validated if they have values
 	RRule *string `json:"rrule,omitempty" example:"FREQ=DAILY;INTERVAL=1;BYHOUR=9"`
 	Cron  *string `json:"cron,omitempty"  example:"0 9 * * *"`
 
 	// Repository event trigger
-	RepositoryEvent *RepositoryEvent `json:"repository_event,omitempty" validate:"required_if=Type repository-event"       example:"post-commit"`
-	Repository      *string          `json:"repository,omitempty"       validate:"required_with=RepositoryEvent,validslug" example:"customer-analytics"` // Slug of the repository
-	RepositoryRef   *string          `json:"repository_ref,omitempty"   validate:"required_with=RepositoryEvent"           example:"main"`
+	RepositoryEvent    *RepositoryEvent `json:"repository_event,omitempty"      validate:"required_if=Type repository-event"       example:"post-commit"`
+	Repository         *string          `json:"repository,omitempty"            validate:"required_with=RepositoryEvent,validslug" example:"customer-analytics"` // Slug of the repository
+	RepositoryRef      *string          `json:"repository_ref,omitempty"        validate:"required_with=RepositoryEvent"           example:"main"`
+	IncludeDiffAsPatch *bool            `json:"include_diff_as_patch,omitempty"` // Generate patches from commit diff for export flows
 
 	// Workflow run event trigger
 	WorkflowRunEvent *WorkflowRunEvent `json:"workflow_run_event,omitempty" validate:"required_if=Type workflow-run-event"                example:"post-workflow-run"`
 	WorkflowID       *string           `json:"workflow_id,omitempty"        validate:"required_with=WorkflowRunEvent,validsqid=workflows" example:"wf_8x2m9k4n7p5q"` // Sqid of the workflow
+
+	// Connection event trigger
+	ConnectionEventType  *ConnectionEventType `json:"connection_event_type,omitempty"`                                             // insert, update, delete, batch
+	ConnectionID         *string              `json:"connection_id,omitempty"          validate:"omitempty,validsqid=connections"` // Sqid of the connection
+	ConnectionEventPaths []string             `json:"connection_event_paths,omitempty"`                                            // Optional path filter (e.g., ["users", "orders"])
 }
 
 type SchemaChangeType string
@@ -1380,9 +1413,10 @@ const (
 type WorkflowTriggerType string
 
 const (
-	TimeTriggerType        WorkflowTriggerType = "time"
-	RepositoryTriggerType  WorkflowTriggerType = "repository-event"
-	WorkflowRunTriggerType WorkflowTriggerType = "workflow-run-event"
+	TimeTriggerType            WorkflowTriggerType = "time"
+	RepositoryTriggerType      WorkflowTriggerType = "repository-event"
+	WorkflowRunTriggerType     WorkflowTriggerType = "workflow-run-event"
+	ConnectionEventTriggerType WorkflowTriggerType = "connection-event"
 )
 type Workflowable struct {
 	Type WorkflowableType `json:"type" validate:"required,oneof=import action export pipeline,validworkflowable" example:"import"`

--- a/docs/html/github_com_IrminData_irmin-sdk-go_models.html
+++ b/docs/html/github_com_IrminData_irmin-sdk-go_models.html
@@ -207,20 +207,21 @@ const (
 	ConnectionEventInsert ConnectionEventType = "insert"
 	ConnectionEventUpdate ConnectionEventType = "update"
 	ConnectionEventDelete ConnectionEventType = "delete"
+	ConnectionEventUpsert ConnectionEventType = "upsert"
 	ConnectionEventBatch  ConnectionEventType = "batch"
 )
 type ConnectionSubscription struct {
-	ID           string   `json:"id"                     validate:"required,validsqid=connection_subscriptions" example:"cs_5p8q2n7m9x4k"`
-	Name         string   `json:"name"                   validate:"required,max=255"                            example:"CRM Lead Changes"`
-	Description  string   `json:"description,omitempty"  validate:"max=1000"                                    example:"Subscribe to lead changes in the CRM"`
-	ConnectionID string   `json:"connection_id"          validate:"required,validsqid=connections"              example:"conn_5p8q2n7m9x4k"`
-	FilterPaths  []string `json:"filter_paths,omitempty" validate:"dive,max=500"                                example:"leads,contacts"`
-	EventTypes   []string `json:"event_types,omitempty"  validate:"dive,oneof=insert update delete upsert"      example:"insert,update"`
-	IsActive     bool     `json:"is_active"                                                                     example:"true"`
-	WebhookURL   string   `json:"webhook_url,omitempty"  validate:"omitempty,url"                               example:"https://api.irmin.co/api/v1/webhooks/connectors/conn_123"`
+	ID           string   `json:"id"                     validate:"required,validsqid=connection_subscriptions"  example:"cs_5p8q2n7m9x4k"`
+	Name         string   `json:"name"                   validate:"required,max=255"                             example:"CRM Lead Changes"`
+	Description  string   `json:"description,omitempty"  validate:"max=1000"                                     example:"Subscribe to lead changes in the CRM"`
+	ConnectionID string   `json:"connection_id"          validate:"required,validsqid=connections"               example:"conn_5p8q2n7m9x4k"`
+	FilterPaths  []string `json:"filter_paths,omitempty" validate:"dive,max=500"                                 example:"leads,contacts"`
+	EventTypes   []string `json:"event_types,omitempty"  validate:"dive,oneof=insert update delete upsert batch" example:"insert,update"`
+	IsActive     bool     `json:"is_active"                                                                      example:"true"`
+	WebhookURL   string   `json:"webhook_url,omitempty"  validate:"omitempty,url"                                example:"https://api.irmin.co/api/v1/webhooks/connectors/conn_123"`
 	Owner        *User    `json:"owner,omitempty"`
-	CreatedAt    string   `json:"created_at,omitempty"                                                          example:"2024-01-15T10:30:00Z"`
-	UpdatedAt    string   `json:"updated_at,omitempty"                                                          example:"2024-01-15T10:30:00Z"`
+	CreatedAt    string   `json:"created_at,omitempty"                                                           example:"2024-01-15T10:30:00Z"`
+	UpdatedAt    string   `json:"updated_at,omitempty"                                                           example:"2024-01-15T10:30:00Z"`
 }
     ConnectionSubscription represents a subscription to data changes in a
     connection. When data changes in the external system, the connector sends

--- a/docs/html/github_com_IrminData_irmin-sdk-go_models.html
+++ b/docs/html/github_com_IrminData_irmin-sdk-go_models.html
@@ -214,8 +214,8 @@ type ConnectionSubscription struct {
 	Name         string   `json:"name"                   validate:"required,max=255"                            example:"CRM Lead Changes"`
 	Description  string   `json:"description,omitempty"  validate:"max=1000"                                    example:"Subscribe to lead changes in the CRM"`
 	ConnectionID string   `json:"connection_id"          validate:"required,validsqid=connections"              example:"conn_5p8q2n7m9x4k"`
-	FilterPaths  []string `json:"filter_paths,omitempty" validate:"dive,max=500"                                example:"["leads", "contacts"]"`
-	EventTypes   []string `json:"event_types,omitempty"  validate:"dive,oneof=insert update delete upsert"      example:"["insert", "update"]"`
+	FilterPaths  []string `json:"filter_paths,omitempty" validate:"dive,max=500"                                example:"leads,contacts"`
+	EventTypes   []string `json:"event_types,omitempty"  validate:"dive,oneof=insert update delete upsert"      example:"insert,update"`
 	IsActive     bool     `json:"is_active"                                                                     example:"true"`
 	WebhookURL   string   `json:"webhook_url,omitempty"  validate:"omitempty,url"                               example:"https://api.irmin.co/api/v1/webhooks/connectors/conn_123"`
 	Owner        *User    `json:"owner,omitempty"`

--- a/docs/html/github_com_IrminData_irmin-sdk-go_models.html
+++ b/docs/html/github_com_IrminData_irmin-sdk-go_models.html
@@ -209,6 +209,30 @@ const (
 	ConnectionEventDelete ConnectionEventType = "delete"
 	ConnectionEventBatch  ConnectionEventType = "batch"
 )
+type ConnectionSubscription struct {
+	ID           string   `json:"id"                     validate:"required,validsqid=connection_subscriptions" example:"cs_5p8q2n7m9x4k"`
+	Name         string   `json:"name"                   validate:"required,max=255"                            example:"CRM Lead Changes"`
+	Description  string   `json:"description,omitempty"  validate:"max=1000"                                    example:"Subscribe to lead changes in the CRM"`
+	ConnectionID string   `json:"connection_id"          validate:"required,validsqid=connections"              example:"conn_5p8q2n7m9x4k"`
+	FilterPaths  []string `json:"filter_paths,omitempty" validate:"dive,max=500"                                example:"["leads", "contacts"]"`
+	EventTypes   []string `json:"event_types,omitempty"  validate:"dive,oneof=insert update delete upsert"      example:"["insert", "update"]"`
+	IsActive     bool     `json:"is_active"                                                                     example:"true"`
+	WebhookURL   string   `json:"webhook_url,omitempty"  validate:"omitempty,url"                               example:"https://api.irmin.co/api/v1/webhooks/connectors/conn_123"`
+	Owner        *User    `json:"owner,omitempty"`
+	CreatedAt    string   `json:"created_at,omitempty"                                                          example:"2024-01-15T10:30:00Z"`
+	UpdatedAt    string   `json:"updated_at,omitempty"                                                          example:"2024-01-15T10:30:00Z"`
+}
+    ConnectionSubscription represents a subscription to data changes in a
+    connection. When data changes in the external system, the connector sends
+    webhook events to the Irmin API using the WebhookToken for authentication.
+
+type ConnectionSubscriptionWithToken struct {
+	ConnectionSubscription
+	WebhookToken string `json:"webhook_token,omitempty" example:"abc123def456..."`
+}
+    ConnectionSubscriptionWithToken includes the webhook token (only returned on
+    creation).
+
 type Connector struct {
 	// ID is a unique SQIDidentifier of the connector
 	ID string `json:"id"                validate:"required,validsqid=connectors"                                                                                                                                  example:"conn_9m3x7k2n8q5p"`
@@ -225,7 +249,7 @@ type Connector struct {
 	// URL to the connector's logo
 	LogoURL string `json:"logo_url"          validate:"required,validimageurl"                                                                                                                                         example:"https://cdn.irmin.dev/mysql.png"`
 	// Array of capabilities of the connector, eg. what kind of operations the connector can perform
-	Capabilities []ConnectorCapability `json:"capabilities"      validate:"required,dive,oneof=pull push push_patch event_webhook"                                                                                                         example:"pull,push"`
+	Capabilities []ConnectorCapability `json:"capabilities"      validate:"required,dive,oneof=pull push apply_patch patch_event"                                                                                                          example:"pull,push"`
 	// Array of locales supported by the connector, eg. what languages the connector supports
 	Locales []string `json:"locales"           validate:"required,dive,min=2,max=5"                                                                                                                                      example:"en,fi"`
 	// Array of categories associated with the connector, eg. what kind of connector it is
@@ -247,10 +271,13 @@ const (
 	ConnectorCapabilityPull ConnectorCapability = "pull"
 	// ConnectorCapabilityPush means that data files can be pushed to different paths in the connector.
 	ConnectorCapabilityPush ConnectorCapability = "push"
-	// ConnectorCapabilityPushPatch means that JSON Patch based change sets can be pushed to the connector.
-	ConnectorCapabilityPushPatch ConnectorCapability = "push_patch"
-	// ConnectorCapabilityEventWebhook means that the connector can send webhook notifications when something changes in the underlying data.
-	ConnectorCapabilityEventWebhook ConnectorCapability = "event_webhook"
+	// ConnectorCapabilityApplyPatch means that the connector can receive and apply patch operations.
+	// Patches follow JSON Patch format (RFC 6902) and can include binary data when the target
+	// data type requires it (e.g., images, files). Binary data is base64-encoded with content_type set.
+	ConnectorCapabilityApplyPatch ConnectorCapability = "apply_patch"
+	// ConnectorCapabilityPatchEvent means that the connector can emit patch events via webhooks
+	// when data changes in the external system. Changes are always expressed as patches.
+	ConnectorCapabilityPatchEvent ConnectorCapability = "patch_event"
 )
 type ConnectorCategory string
     ConnectorCategory represents the category of a connector.

--- a/docs/html/index.html
+++ b/docs/html/index.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8"/>
 <title>github.com/IrminData/irmin-sdk-go documentation</title>
 <h1>github.com/IrminData/irmin-sdk-go documentation</h1>
-<p>Generated on 2026-01-21 10:42 UTC</p>
+<p>Generated on 2026-01-21 10:47 UTC</p>
 <ul>
 <li><a href="github_com_IrminData_irmin-sdk-go.html">github.com/IrminData/irmin-sdk-go</a></li>
 <li><a href="github_com_IrminData_irmin-sdk-go_api.html">github.com/IrminData/irmin-sdk-go/api</a></li>

--- a/docs/html/index.html
+++ b/docs/html/index.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8"/>
 <title>github.com/IrminData/irmin-sdk-go documentation</title>
 <h1>github.com/IrminData/irmin-sdk-go documentation</h1>
-<p>Generated on 2026-01-21 09:24 UTC</p>
+<p>Generated on 2026-01-21 10:36 UTC</p>
 <ul>
 <li><a href="github_com_IrminData_irmin-sdk-go.html">github.com/IrminData/irmin-sdk-go</a></li>
 <li><a href="github_com_IrminData_irmin-sdk-go_api.html">github.com/IrminData/irmin-sdk-go/api</a></li>

--- a/docs/html/index.html
+++ b/docs/html/index.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8"/>
 <title>github.com/IrminData/irmin-sdk-go documentation</title>
 <h1>github.com/IrminData/irmin-sdk-go documentation</h1>
-<p>Generated on 2026-01-21 10:36 UTC</p>
+<p>Generated on 2026-01-21 10:42 UTC</p>
 <ul>
 <li><a href="github_com_IrminData_irmin-sdk-go.html">github.com/IrminData/irmin-sdk-go</a></li>
 <li><a href="github_com_IrminData_irmin-sdk-go_api.html">github.com/IrminData/irmin-sdk-go/api</a></li>

--- a/docs/html/index.html
+++ b/docs/html/index.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8"/>
 <title>github.com/IrminData/irmin-sdk-go documentation</title>
 <h1>github.com/IrminData/irmin-sdk-go documentation</h1>
-<p>Generated on 2026-01-20 16:55 UTC</p>
+<p>Generated on 2026-01-21 09:24 UTC</p>
 <ul>
 <li><a href="github_com_IrminData_irmin-sdk-go.html">github.com/IrminData/irmin-sdk-go</a></li>
 <li><a href="github_com_IrminData_irmin-sdk-go_api.html">github.com/IrminData/irmin-sdk-go/api</a></li>

--- a/models/connection_subscription.go
+++ b/models/connection_subscription.go
@@ -4,17 +4,17 @@ package irminmodels
 // When data changes in the external system, the connector sends webhook events
 // to the Irmin API using the WebhookToken for authentication.
 type ConnectionSubscription struct {
-	ID           string   `json:"id"                     validate:"required,validsqid=connection_subscriptions" example:"cs_5p8q2n7m9x4k"`
-	Name         string   `json:"name"                   validate:"required,max=255"                            example:"CRM Lead Changes"`
-	Description  string   `json:"description,omitempty"  validate:"max=1000"                                    example:"Subscribe to lead changes in the CRM"`
-	ConnectionID string   `json:"connection_id"          validate:"required,validsqid=connections"              example:"conn_5p8q2n7m9x4k"`
-	FilterPaths  []string `json:"filter_paths,omitempty" validate:"dive,max=500"                                example:"leads,contacts"`
-	EventTypes   []string `json:"event_types,omitempty"  validate:"dive,oneof=insert update delete upsert"      example:"insert,update"`
-	IsActive     bool     `json:"is_active"                                                                     example:"true"`
-	WebhookURL   string   `json:"webhook_url,omitempty"  validate:"omitempty,url"                               example:"https://api.irmin.co/api/v1/webhooks/connectors/conn_123"`
+	ID           string   `json:"id"                     validate:"required,validsqid=connection_subscriptions"  example:"cs_5p8q2n7m9x4k"`
+	Name         string   `json:"name"                   validate:"required,max=255"                             example:"CRM Lead Changes"`
+	Description  string   `json:"description,omitempty"  validate:"max=1000"                                     example:"Subscribe to lead changes in the CRM"`
+	ConnectionID string   `json:"connection_id"          validate:"required,validsqid=connections"               example:"conn_5p8q2n7m9x4k"`
+	FilterPaths  []string `json:"filter_paths,omitempty" validate:"dive,max=500"                                 example:"leads,contacts"`
+	EventTypes   []string `json:"event_types,omitempty"  validate:"dive,oneof=insert update delete upsert batch" example:"insert,update"`
+	IsActive     bool     `json:"is_active"                                                                      example:"true"`
+	WebhookURL   string   `json:"webhook_url,omitempty"  validate:"omitempty,url"                                example:"https://api.irmin.co/api/v1/webhooks/connectors/conn_123"`
 	Owner        *User    `json:"owner,omitempty"`
-	CreatedAt    string   `json:"created_at,omitempty"                                                          example:"2024-01-15T10:30:00Z"`
-	UpdatedAt    string   `json:"updated_at,omitempty"                                                          example:"2024-01-15T10:30:00Z"`
+	CreatedAt    string   `json:"created_at,omitempty"                                                           example:"2024-01-15T10:30:00Z"`
+	UpdatedAt    string   `json:"updated_at,omitempty"                                                           example:"2024-01-15T10:30:00Z"`
 }
 
 // ConnectionSubscriptionWithToken includes the webhook token (only returned on creation).

--- a/models/connection_subscription.go
+++ b/models/connection_subscription.go
@@ -4,17 +4,17 @@ package irminmodels
 // When data changes in the external system, the connector sends webhook events
 // to the Irmin API using the WebhookToken for authentication.
 type ConnectionSubscription struct {
-	ID           string   `json:"id"                     validate:"required,validsqid=connection_subscriptions"  example:"cs_5p8q2n7m9x4k"`
-	Name         string   `json:"name"                   validate:"required,max=255"                             example:"CRM Lead Changes"`
-	Description  string   `json:"description,omitempty"  validate:"max=1000"                                     example:"Subscribe to lead changes in the CRM"`
-	ConnectionID string   `json:"connection_id"          validate:"required,validsqid=connections"               example:"conn_5p8q2n7m9x4k"`
-	FilterPaths  []string `json:"filter_paths,omitempty" validate:"dive,max=500"                                 example:"[\"leads\", \"contacts\"]"`
-	EventTypes   []string `json:"event_types,omitempty"  validate:"dive,oneof=insert update delete upsert"       example:"[\"insert\", \"update\"]"`
-	IsActive     bool     `json:"is_active"                                                                      example:"true"`
-	WebhookURL   string   `json:"webhook_url,omitempty"  validate:"omitempty,url"                                example:"https://api.irmin.co/api/v1/webhooks/connectors/conn_123"`
+	ID           string   `json:"id"                     validate:"required,validsqid=connection_subscriptions" example:"cs_5p8q2n7m9x4k"`
+	Name         string   `json:"name"                   validate:"required,max=255"                            example:"CRM Lead Changes"`
+	Description  string   `json:"description,omitempty"  validate:"max=1000"                                    example:"Subscribe to lead changes in the CRM"`
+	ConnectionID string   `json:"connection_id"          validate:"required,validsqid=connections"              example:"conn_5p8q2n7m9x4k"`
+	FilterPaths  []string `json:"filter_paths,omitempty" validate:"dive,max=500"                                example:"["leads", "contacts"]"`
+	EventTypes   []string `json:"event_types,omitempty"  validate:"dive,oneof=insert update delete upsert"      example:"["insert", "update"]"`
+	IsActive     bool     `json:"is_active"                                                                     example:"true"`
+	WebhookURL   string   `json:"webhook_url,omitempty"  validate:"omitempty,url"                               example:"https://api.irmin.co/api/v1/webhooks/connectors/conn_123"`
 	Owner        *User    `json:"owner,omitempty"`
-	CreatedAt    string   `json:"created_at,omitempty"                                                           example:"2024-01-15T10:30:00Z"`
-	UpdatedAt    string   `json:"updated_at,omitempty"                                                           example:"2024-01-15T10:30:00Z"`
+	CreatedAt    string   `json:"created_at,omitempty"                                                          example:"2024-01-15T10:30:00Z"`
+	UpdatedAt    string   `json:"updated_at,omitempty"                                                          example:"2024-01-15T10:30:00Z"`
 }
 
 // ConnectionSubscriptionWithToken includes the webhook token (only returned on creation).

--- a/models/connection_subscription.go
+++ b/models/connection_subscription.go
@@ -1,0 +1,24 @@
+package irminmodels
+
+// ConnectionSubscription represents a subscription to data changes in a connection.
+// When data changes in the external system, the connector sends webhook events
+// to the Irmin API using the WebhookToken for authentication.
+type ConnectionSubscription struct {
+	ID           string   `json:"id"                     validate:"required,validsqid=connection_subscriptions"  example:"cs_5p8q2n7m9x4k"`
+	Name         string   `json:"name"                   validate:"required,max=255"                             example:"CRM Lead Changes"`
+	Description  string   `json:"description,omitempty"  validate:"max=1000"                                     example:"Subscribe to lead changes in the CRM"`
+	ConnectionID string   `json:"connection_id"          validate:"required,validsqid=connections"               example:"conn_5p8q2n7m9x4k"`
+	FilterPaths  []string `json:"filter_paths,omitempty" validate:"dive,max=500"                                 example:"[\"leads\", \"contacts\"]"`
+	EventTypes   []string `json:"event_types,omitempty"  validate:"dive,oneof=insert update delete upsert"       example:"[\"insert\", \"update\"]"`
+	IsActive     bool     `json:"is_active"                                                                      example:"true"`
+	WebhookURL   string   `json:"webhook_url,omitempty"  validate:"omitempty,url"                                example:"https://api.irmin.co/api/v1/webhooks/connectors/conn_123"`
+	Owner        *User    `json:"owner,omitempty"`
+	CreatedAt    string   `json:"created_at,omitempty"                                                           example:"2024-01-15T10:30:00Z"`
+	UpdatedAt    string   `json:"updated_at,omitempty"                                                           example:"2024-01-15T10:30:00Z"`
+}
+
+// ConnectionSubscriptionWithToken includes the webhook token (only returned on creation).
+type ConnectionSubscriptionWithToken struct {
+	ConnectionSubscription
+	WebhookToken string `json:"webhook_token,omitempty" example:"abc123def456..."`
+}

--- a/models/connection_subscription.go
+++ b/models/connection_subscription.go
@@ -8,8 +8,8 @@ type ConnectionSubscription struct {
 	Name         string   `json:"name"                   validate:"required,max=255"                            example:"CRM Lead Changes"`
 	Description  string   `json:"description,omitempty"  validate:"max=1000"                                    example:"Subscribe to lead changes in the CRM"`
 	ConnectionID string   `json:"connection_id"          validate:"required,validsqid=connections"              example:"conn_5p8q2n7m9x4k"`
-	FilterPaths  []string `json:"filter_paths,omitempty" validate:"dive,max=500"                                example:"["leads", "contacts"]"`
-	EventTypes   []string `json:"event_types,omitempty"  validate:"dive,oneof=insert update delete upsert"      example:"["insert", "update"]"`
+	FilterPaths  []string `json:"filter_paths,omitempty" validate:"dive,max=500"                                example:"leads,contacts"`
+	EventTypes   []string `json:"event_types,omitempty"  validate:"dive,oneof=insert update delete upsert"      example:"insert,update"`
 	IsActive     bool     `json:"is_active"                                                                     example:"true"`
 	WebhookURL   string   `json:"webhook_url,omitempty"  validate:"omitempty,url"                               example:"https://api.irmin.co/api/v1/webhooks/connectors/conn_123"`
 	Owner        *User    `json:"owner,omitempty"`

--- a/models/connector.go
+++ b/models/connector.go
@@ -17,7 +17,7 @@ type Connector struct {
 	// URL to the connector's logo
 	LogoURL string `json:"logo_url"          validate:"required,validimageurl"                                                                                                                                         example:"https://cdn.irmin.dev/mysql.png"`
 	// Array of capabilities of the connector, eg. what kind of operations the connector can perform
-	Capabilities []ConnectorCapability `json:"capabilities"      validate:"required,dive,oneof=pull push push_patch event_webhook"                                                                                                         example:"pull,push"`
+	Capabilities []ConnectorCapability `json:"capabilities"      validate:"required,dive,oneof=pull push apply_patch patch_event"                                                                                                          example:"pull,push"`
 	// Array of locales supported by the connector, eg. what languages the connector supports
 	Locales []string `json:"locales"           validate:"required,dive,min=2,max=5"                                                                                                                                      example:"en,fi"`
 	// Array of categories associated with the connector, eg. what kind of connector it is
@@ -38,10 +38,13 @@ const (
 	ConnectorCapabilityPull ConnectorCapability = "pull"
 	// ConnectorCapabilityPush means that data files can be pushed to different paths in the connector.
 	ConnectorCapabilityPush ConnectorCapability = "push"
-	// ConnectorCapabilityPushPatch means that JSON Patch based change sets can be pushed to the connector.
-	ConnectorCapabilityPushPatch ConnectorCapability = "push_patch"
-	// ConnectorCapabilityEventWebhook means that the connector can send webhook notifications when something changes in the underlying data.
-	ConnectorCapabilityEventWebhook ConnectorCapability = "event_webhook"
+	// ConnectorCapabilityApplyPatch means that the connector can receive and apply patch operations.
+	// Patches follow JSON Patch format (RFC 6902) and can include binary data when the target
+	// data type requires it (e.g., images, files). Binary data is base64-encoded with content_type set.
+	ConnectorCapabilityApplyPatch ConnectorCapability = "apply_patch"
+	// ConnectorCapabilityPatchEvent means that the connector can emit patch events via webhooks
+	// when data changes in the external system. Changes are always expressed as patches.
+	ConnectorCapabilityPatchEvent ConnectorCapability = "patch_event"
 )
 
 // ConnectorCategory represents the category of a connector.

--- a/models/json_patch.go
+++ b/models/json_patch.go
@@ -3,13 +3,16 @@ package irminmodels
 // PatchOperation represents a single operation in a JSON Patch array.
 type PatchOperation struct {
 	// The operation: "add", "remove", "replace", "move" or "copy"
-	Op string `json:"op"              validate:"required,oneof=add remove replace move copy" example:"replace"`
+	Op string `json:"op"                     validate:"required,oneof=add remove replace move copy" example:"replace"`
 	// The JSON-Pointer location to apply the operation
-	Path string `json:"path"            validate:"required"                                    example:"/users.json/1/name"`
+	Path string `json:"path"                   validate:"required"                                    example:"/users.json/1/name"`
 	// Used for "move" or "copy" operations
-	From *string `json:"from,omitempty"  validate:"required_if=Op move,required_if=Op copy"     example:"/users.json/1/name"`
+	From *string `json:"from,omitempty"         validate:"required_if=Op move,required_if=Op copy"     example:"/users.json/1/name"`
 	// Used for "add" or "replace" operations
-	Value *any `json:"value,omitempty" validate:"required_if=Op add,required_if=Op replace"   example:"John"`
+	Value *any `json:"value,omitempty"        validate:"required_if=Op add,required_if=Op replace"   example:"John"`
+	// ContentType indicates the MIME type for binary data.
+	// When set, Value should be base64-encoded binary content.
+	ContentType *string `json:"content_type,omitempty"                                                        example:"image/png"`
 }
 
 // Patch is a series of patch operations.

--- a/models/schedule.go
+++ b/models/schedule.go
@@ -31,6 +31,7 @@ const (
 	ConnectionEventInsert ConnectionEventType = "insert"
 	ConnectionEventUpdate ConnectionEventType = "update"
 	ConnectionEventDelete ConnectionEventType = "delete"
+	ConnectionEventUpsert ConnectionEventType = "upsert"
 	ConnectionEventBatch  ConnectionEventType = "batch"
 )
 

--- a/models/schedule.go
+++ b/models/schedule.go
@@ -24,29 +24,46 @@ const (
 	PostWorkflowRun WorkflowRunEvent = "post-workflow-run"
 )
 
+// ConnectionEventType represents the type of change event from a connector
+type ConnectionEventType string
+
+const (
+	ConnectionEventInsert ConnectionEventType = "insert"
+	ConnectionEventUpdate ConnectionEventType = "update"
+	ConnectionEventDelete ConnectionEventType = "delete"
+	ConnectionEventBatch  ConnectionEventType = "batch"
+)
+
 type WorkflowTriggerType string
 
 const (
-	TimeTriggerType        WorkflowTriggerType = "time"
-	RepositoryTriggerType  WorkflowTriggerType = "repository-event"
-	WorkflowRunTriggerType WorkflowTriggerType = "workflow-run-event"
+	TimeTriggerType            WorkflowTriggerType = "time"
+	RepositoryTriggerType      WorkflowTriggerType = "repository-event"
+	WorkflowRunTriggerType     WorkflowTriggerType = "workflow-run-event"
+	ConnectionEventTriggerType WorkflowTriggerType = "connection-event"
 )
 
 type ScheduleTrigger struct {
-	Type WorkflowTriggerType `json:"type" validate:"required,oneof=time repository-event workflow-run-event,validschedule" example:"time"`
+	Type WorkflowTriggerType `json:"type" validate:"required,oneof=time repository-event workflow-run-event connection-event,validschedule" example:"time"`
 
 	// Time trigger - these should only be validated if they have values
 	RRule *string `json:"rrule,omitempty" example:"FREQ=DAILY;INTERVAL=1;BYHOUR=9"`
 	Cron  *string `json:"cron,omitempty"  example:"0 9 * * *"`
 
 	// Repository event trigger
-	RepositoryEvent *RepositoryEvent `json:"repository_event,omitempty" validate:"required_if=Type repository-event"       example:"post-commit"`
-	Repository      *string          `json:"repository,omitempty"       validate:"required_with=RepositoryEvent,validslug" example:"customer-analytics"` // Slug of the repository
-	RepositoryRef   *string          `json:"repository_ref,omitempty"   validate:"required_with=RepositoryEvent"           example:"main"`
+	RepositoryEvent    *RepositoryEvent `json:"repository_event,omitempty"      validate:"required_if=Type repository-event"       example:"post-commit"`
+	Repository         *string          `json:"repository,omitempty"            validate:"required_with=RepositoryEvent,validslug" example:"customer-analytics"` // Slug of the repository
+	RepositoryRef      *string          `json:"repository_ref,omitempty"        validate:"required_with=RepositoryEvent"           example:"main"`
+	IncludeDiffAsPatch *bool            `json:"include_diff_as_patch,omitempty"` // Generate patches from commit diff for export flows
 
 	// Workflow run event trigger
 	WorkflowRunEvent *WorkflowRunEvent `json:"workflow_run_event,omitempty" validate:"required_if=Type workflow-run-event"                example:"post-workflow-run"`
 	WorkflowID       *string           `json:"workflow_id,omitempty"        validate:"required_with=WorkflowRunEvent,validsqid=workflows" example:"wf_8x2m9k4n7p5q"` // Sqid of the workflow
+
+	// Connection event trigger
+	ConnectionEventType  *ConnectionEventType `json:"connection_event_type,omitempty"`                                             // insert, update, delete, batch
+	ConnectionID         *string              `json:"connection_id,omitempty"          validate:"omitempty,validsqid=connections"` // Sqid of the connection
+	ConnectionEventPaths []string             `json:"connection_event_paths,omitempty"`                                            // Optional path filter (e.g., ["users", "orders"])
 }
 
 type Schedule struct {

--- a/models/workflow.go
+++ b/models/workflow.go
@@ -40,6 +40,7 @@ const (
 	PipelineStageTypeValidation       PipelineStageType = "validation"
 	PipelineStageTypeTransform        PipelineStageType = "transform"
 	PipelineStageTypeEmbeddings       PipelineStageType = "embeddings"
+	PipelineStageTypePatch            PipelineStageType = "patch"
 )
 
 // TransformOperationType represents the type of transformation to apply.
@@ -76,6 +77,14 @@ const (
 	EmbeddingsOpSearch    EmbeddingsOperationType = "search"
 )
 
+// PatchDirection represents the direction of a patch operation.
+type PatchDirection string
+
+const (
+	PatchDirectionToConnection PatchDirection = "to_connection"
+	PatchDirectionToRepository PatchDirection = "to_repository"
+)
+
 type RepositoryActionType string
 
 const (
@@ -86,11 +95,11 @@ const (
 )
 
 type PipelineStage struct {
-	Description   string            `json:"description"    validate:"required,max=200"                                                                                                                  example:"Process customer data"`
-	Write         bool              `json:"write"                                                                                                                                                       example:"true"`
-	Read          bool              `json:"read"                                                                                                                                                        example:"true"`
-	OrderSequence int               `json:"order_sequence"                                                                                                                                              example:"1"`
-	Type          PipelineStageType `json:"type"           validate:"required,oneof=action connection repository repository_action trigger_workflow validation transform embeddings,validpipelinestage" example:"repository"`
+	Description   string            `json:"description"    validate:"required,max=200"                                                                                                                        example:"Process customer data"`
+	Write         bool              `json:"write"                                                                                                                                                             example:"true"`
+	Read          bool              `json:"read"                                                                                                                                                              example:"true"`
+	OrderSequence int               `json:"order_sequence"                                                                                                                                                    example:"1"`
+	Type          PipelineStageType `json:"type"           validate:"required,oneof=action connection repository repository_action trigger_workflow validation transform embeddings patch,validpipelinestage" example:"repository"`
 
 	// Action stage specific
 	ExecutableType ActionExecutableType `json:"executable_type,omitempty" validate:"omitempty,oneof=script query,required_if=Type action"          example:"script"`
@@ -151,6 +160,13 @@ type PipelineStage struct {
 	EmbeddingsQuery      *string                  `json:"embeddings_query,omitempty"       validate:"omitempty"                                                    example:"What is machine learning?"`
 	EmbeddingsTopK       *int                     `json:"embeddings_top_k,omitempty"       validate:"omitempty,min=1"                                              example:"10"`
 	EmbeddingsFilter     map[string]string        `json:"embeddings_filter,omitempty"      validate:"omitempty"`
+
+	// Patch stage specific
+	PatchDirection        *PatchDirection `json:"patch_direction,omitempty"         validate:"omitempty,oneof=to_connection to_repository,required_if=Type patch" example:"to_connection"`
+	PatchConnectionID     *string         `json:"patch_connection_id,omitempty"     validate:"omitempty,validsqid=connections"                                    example:"conn_8x2m9k4n7p5q"`
+	PatchRepository       *string         `json:"patch_repository,omitempty"        validate:"omitempty"                                                          example:"customer-analytics"`
+	PatchRepositoryBranch *string         `json:"patch_repository_branch,omitempty" validate:"omitempty"                                                          example:"main"`
+	PatchSourceFileName   *string         `json:"patch_source_file_name,omitempty"  validate:"omitempty"                                                          example:"patches.json"`
 }
 
 type ActionInputData struct {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds first-class support for connector-driven change delivery and patch-based workflows.
> 
> - New `ConnectionSubscription` models (incl. `ConnectionSubscriptionWithToken`) and API request types (`CreateConnectionSubscriptionRequest`, `UpdateConnectionSubscriptionRequest`); introduces `ConnectionEventType`
> - Scheduling: adds `connection-event` trigger with optional `connection_event_paths` and `include_diff_as_patch`
> - Connector capabilities updated: replaces `push_patch`/`event_webhook` with `apply_patch`/`patch_event`
> - JSON Patch enhancements: `PatchOperation` gains `content_type`; new `PatchDirection`
> - Workflows: adds `patch` `PipelineStageType` with fields for direction and sources
> - API: adds `ResetBranch` and `ResetBranchRequest`
> - Regenerated docs to reflect new types and methods
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2b2801c83fa35d3c05adce951e54a8fab4c17964. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->