### PR TITLE
Tim/feat/revert commits

### DIFF
--- a/api/repository-branches.go
+++ b/api/repository-branches.go
@@ -30,8 +30,8 @@ type ResetBranchRequest struct {
 // RevertCommitRequest represents the JSON request body for reverting a commit.
 // This creates a new commit that undoes the changes from the specified commit.
 type RevertCommitRequest struct {
-	CommitRef    string `json:"commit_ref"               validate:"required" example:"abc123def456"`
-	ParentNumber int    `json:"parent_number,omitempty"                      example:"0"`
+	CommitRef    string `json:"commit_ref"              validate:"required" example:"abc123def456"`
+	ParentNumber int    `json:"parent_number,omitempty"                     example:"0"`
 }
 
 func (c *Client) ListBranches(

--- a/api/repository-branches.go
+++ b/api/repository-branches.go
@@ -27,6 +27,13 @@ type ResetBranchRequest struct {
 	Force     bool   `json:"force,omitempty"                     example:"false"`
 }
 
+// RevertCommitRequest represents the JSON request body for reverting a commit.
+// This creates a new commit that undoes the changes from the specified commit.
+type RevertCommitRequest struct {
+	CommitRef    string `json:"commit_ref"               validate:"required" example:"abc123def456"`
+	ParentNumber int    `json:"parent_number,omitempty"                      example:"0"`
+}
+
 func (c *Client) ListBranches(
 	ctx context.Context,
 	workspace, repository string,
@@ -148,4 +155,25 @@ func (c *Client) ResetBranch(
 		return nil, fmt.Errorf("reset branch error: %w", err)
 	}
 	return apiResp, nil
+}
+
+// RevertCommit reverts a commit on a branch by creating a new commit that undoes its changes.
+// This is a non-destructive operation that preserves history.
+// ParentNumber is used for merge commits to specify which parent to follow (0 = first parent).
+func (c *Client) RevertCommit(
+	ctx context.Context,
+	workspace, repository, branch string,
+	req RevertCommitRequest,
+) (*irminmodels.Commit, *irminmodels.IrminAPIResponse, error) {
+	var commit irminmodels.Commit
+	apiResp, err := c.FetchAPI(ctx, RequestOptions{
+		Method:      http.MethodPost,
+		Endpoint:    fmt.Sprintf("/v1/workspaces/%s/repositories/%s/branches/%s/revert", workspace, repository, branch),
+		ContentType: "application/json",
+		Body:        req,
+	}, &commit)
+	if err != nil {
+		return nil, nil, fmt.Errorf("revert commit error: %w", err)
+	}
+	return &commit, apiResp, nil
 }

--- a/api/repository-branches.go
+++ b/api/repository-branches.go
@@ -31,7 +31,7 @@ type ResetBranchRequest struct {
 // This creates a new commit that undoes the changes from the specified commit.
 type RevertCommitRequest struct {
 	CommitRef    string `json:"commit_ref"              validate:"required" example:"abc123def456"`
-	ParentNumber int    `json:"parent_number,omitempty"                     example:"0"`
+	ParentNumber *int   `json:"parent_number,omitempty"                     example:"0"`
 }
 
 func (c *Client) ListBranches(

--- a/docs/docs.md
+++ b/docs/docs.md
@@ -2742,8 +2742,8 @@ RevertCommitRequest represents the JSON request body for reverting a commit. Thi
 
 ```go
 type RevertCommitRequest struct {
-    CommitRef    string `json:"commit_ref"               validate:"required" example:"abc123def456"`
-    ParentNumber int    `json:"parent_number,omitempty"                      example:"0"`
+    CommitRef    string `json:"commit_ref"              validate:"required" example:"abc123def456"`
+    ParentNumber *int   `json:"parent_number,omitempty"                     example:"0"`
 }
 ```
 

--- a/docs/docs.md
+++ b/docs/docs.md
@@ -291,6 +291,7 @@ import "github.com/IrminData/irmin-sdk-go/api"
   - [func \(c \*Client\) ResendInvite\(ctx context.Context, inviteID string\) \(\*irminmodels.Invite, \*irminmodels.IrminAPIResponse, error\)](<#Client.ResendInvite>)
   - [func \(c \*Client\) ResetBranch\(ctx context.Context, workspace, repository, branch string, req ResetBranchRequest\) \(\*irminmodels.IrminAPIResponse, error\)](<#Client.ResetBranch>)
   - [func \(c \*Client\) RevertChanges\(ctx context.Context, workspace, repository string, req RevertUncommittedChangesRequest\) \(\*irminmodels.IrminAPIResponse, error\)](<#Client.RevertChanges>)
+  - [func \(c \*Client\) RevertCommit\(ctx context.Context, workspace, repository, branch string, req RevertCommitRequest\) \(\*irminmodels.Commit, \*irminmodels.IrminAPIResponse, error\)](<#Client.RevertCommit>)
   - [func \(c \*Client\) Search\(ctx context.Context, workspace string, params irminmodels.SearchFilters\) \(\*irminmodels.SearchResponse, \*irminmodels.IrminAPIResponse, error\)](<#Client.Search>)
   - [func \(c \*Client\) SearchEmbeddings\(ctx context.Context, workspace, repository string, req SearchEmbeddingsRequest\) \(\*irminmodels.EmbeddingSearchResponse, \*irminmodels.IrminAPIResponse, error\)](<#Client.SearchEmbeddings>)
   - [func \(c \*Client\) SendInvite\(ctx context.Context, workspace string, req SendInviteRequest\) \(\*irminmodels.Invite, \*irminmodels.IrminAPIResponse, error\)](<#Client.SendInvite>)
@@ -363,6 +364,7 @@ import "github.com/IrminData/irmin-sdk-go/api"
 - [type MoveObjectRequest](<#MoveObjectRequest>)
 - [type RequestOptions](<#RequestOptions>)
 - [type ResetBranchRequest](<#ResetBranchRequest>)
+- [type RevertCommitRequest](<#RevertCommitRequest>)
 - [type RevertUncommittedChangesRequest](<#RevertUncommittedChangesRequest>)
 - [type SearchEmbeddingsRequest](<#SearchEmbeddingsRequest>)
 - [type SendInviteRequest](<#SendInviteRequest>)
@@ -1891,6 +1893,15 @@ func (c *Client) RevertChanges(ctx context.Context, workspace, repository string
 
 
 
+<a name="Client.RevertCommit"></a>
+### func \(\*Client\) RevertCommit
+
+```go
+func (c *Client) RevertCommit(ctx context.Context, workspace, repository, branch string, req RevertCommitRequest) (*irminmodels.Commit, *irminmodels.IrminAPIResponse, error)
+```
+
+RevertCommit reverts a commit on a branch by creating a new commit that undoes its changes. This is a non\-destructive operation that preserves history. ParentNumber is used for merge commits to specify which parent to follow \(0 = first parent\).
+
 <a name="Client.Search"></a>
 ### func \(\*Client\) Search
 
@@ -2721,6 +2732,18 @@ ResetBranchRequest represents the JSON request body for resetting a branch to a 
 type ResetBranchRequest struct {
     CommitRef string `json:"commit_ref"      validate:"required" example:"abc123def456"`
     Force     bool   `json:"force,omitempty"                     example:"false"`
+}
+```
+
+<a name="RevertCommitRequest"></a>
+## type RevertCommitRequest
+
+RevertCommitRequest represents the JSON request body for reverting a commit. This creates a new commit that undoes the changes from the specified commit.
+
+```go
+type RevertCommitRequest struct {
+    CommitRef    string `json:"commit_ref"               validate:"required" example:"abc123def456"`
+    ParentNumber int    `json:"parent_number,omitempty"                      example:"0"`
 }
 ```
 

--- a/docs/html/github_com_IrminData_irmin-sdk-go_api.html
+++ b/docs/html/github_com_IrminData_irmin-sdk-go_api.html
@@ -950,6 +950,16 @@ func (c *Client) RevertChanges(
 	req RevertUncommittedChangesRequest,
 ) (*irminmodels.IrminAPIResponse, error)
 
+func (c *Client) RevertCommit(
+	ctx context.Context,
+	workspace, repository, branch string,
+	req RevertCommitRequest,
+) (*irminmodels.Commit, *irminmodels.IrminAPIResponse, error)
+    RevertCommit reverts a commit on a branch by creating a new commit that
+    undoes its changes. This is a non-destructive operation that preserves
+    history. ParentNumber is used for merge commits to specify which parent to
+    follow (0 = first parent).
+
 func (c *Client) Search(
 	ctx context.Context,
 	workspace string,
@@ -1495,6 +1505,13 @@ type ResetBranchRequest struct {
 }
     ResetBranchRequest represents the JSON request body for resetting a branch
     to a specific commit.
+
+type RevertCommitRequest struct {
+	CommitRef    string `json:"commit_ref"               validate:"required" example:"abc123def456"`
+	ParentNumber int    `json:"parent_number,omitempty"                      example:"0"`
+}
+    RevertCommitRequest represents the JSON request body for reverting a commit.
+    This creates a new commit that undoes the changes from the specified commit.
 
 type RevertUncommittedChangesRequest struct {
 	Branch   string `json:"branch"              validate:"required" example:"main"`

--- a/docs/html/github_com_IrminData_irmin-sdk-go_api.html
+++ b/docs/html/github_com_IrminData_irmin-sdk-go_api.html
@@ -1507,8 +1507,8 @@ type ResetBranchRequest struct {
     to a specific commit.
 
 type RevertCommitRequest struct {
-	CommitRef    string `json:"commit_ref"               validate:"required" example:"abc123def456"`
-	ParentNumber int    `json:"parent_number,omitempty"                      example:"0"`
+	CommitRef    string `json:"commit_ref"              validate:"required" example:"abc123def456"`
+	ParentNumber *int   `json:"parent_number,omitempty"                     example:"0"`
 }
     RevertCommitRequest represents the JSON request body for reverting a commit.
     This creates a new commit that undoes the changes from the specified commit.

--- a/docs/html/index.html
+++ b/docs/html/index.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8"/>
 <title>github.com/IrminData/irmin-sdk-go documentation</title>
 <h1>github.com/IrminData/irmin-sdk-go documentation</h1>
-<p>Generated on 2026-01-26 12:41 UTC</p>
+<p>Generated on 2026-01-26 12:46 UTC</p>
 <ul>
 <li><a href="github_com_IrminData_irmin-sdk-go.html">github.com/IrminData/irmin-sdk-go</a></li>
 <li><a href="github_com_IrminData_irmin-sdk-go_api.html">github.com/IrminData/irmin-sdk-go/api</a></li>

--- a/docs/html/index.html
+++ b/docs/html/index.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8"/>
 <title>github.com/IrminData/irmin-sdk-go documentation</title>
 <h1>github.com/IrminData/irmin-sdk-go documentation</h1>
-<p>Generated on 2026-01-22 21:38 UTC</p>
+<p>Generated on 2026-01-26 12:41 UTC</p>
 <ul>
 <li><a href="github_com_IrminData_irmin-sdk-go.html">github.com/IrminData/irmin-sdk-go</a></li>
 <li><a href="github_com_IrminData_irmin-sdk-go_api.html">github.com/IrminData/irmin-sdk-go/api</a></li>

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/klauspost/cpuid/v2 v2.3.0 // indirect
 	github.com/leodido/go-urn v1.4.0 // indirect
 	github.com/pierrec/lz4/v4 v4.1.25 // indirect
-	github.com/zeebo/xxh3 v1.0.2 // indirect
+	github.com/zeebo/xxh3 v1.1.0 // indirect
 	golang.org/x/crypto v0.47.0 // indirect
 	golang.org/x/exp v0.0.0-20260112195511-716be5621a96 // indirect
 	golang.org/x/mod v0.32.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -56,8 +56,8 @@ github.com/teambition/rrule-go v1.8.2 h1:lIjpjvWTj9fFUZCmuoVDrKVOtdiyzbzc93qTmRV
 github.com/teambition/rrule-go v1.8.2/go.mod h1:Ieq5AbrKGciP1V//Wq8ktsTXwSwJHDD5mD/wLBGl3p4=
 github.com/zeebo/assert v1.3.0 h1:g7C04CbJuIDKNPFHmsk4hwZDO5O+kntRxzaUoNXj+IQ=
 github.com/zeebo/assert v1.3.0/go.mod h1:Pq9JiuJQpG8JLJdtkwrJESF0Foym2/D9XMU5ciN/wJ0=
-github.com/zeebo/xxh3 v1.0.2 h1:xZmwmqxHZA8AI603jOQ0tMqmBr9lPeFwGg6d+xy9DC0=
-github.com/zeebo/xxh3 v1.0.2/go.mod h1:5NWz9Sef7zIDm2JHfFlcQvNekmcEl9ekUZQQKCYaDcA=
+github.com/zeebo/xxh3 v1.1.0 h1:s7DLGDK45Dyfg7++yxI0khrfwq9661w9EN78eP/UZVs=
+github.com/zeebo/xxh3 v1.1.0/go.mod h1:IisAie1LELR4xhVinxWS5+zf1lA4p0MW4T+w+W07F5s=
 golang.org/x/crypto v0.47.0 h1:V6e3FRj+n4dbpw86FJ8Fv7XVOql7TEwpHapKoMJ/GO8=
 golang.org/x/crypto v0.47.0/go.mod h1:ff3Y9VzzKbwSSEzWqJsJVBnWmRwRSHt/6Op5n9bQc4A=
 golang.org/x/exp v0.0.0-20260112195511-716be5621a96 h1:Z/6YuSHTLOHfNFdb8zVZomZr7cqNgTJvA8+Qz75D8gU=


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces a non-destructive commit revert operation in the branches client.
> 
> - Adds `RevertCommitRequest` and `Client.RevertCommit` (POST `.../branches/{branch}/revert`) returning `irminmodels.Commit`; supports `parent_number` for merge commits
> - Updates docs (`docs.md`, HTML) to include the new method/type; regenerates index timestamp
> - Bumps `github.com/zeebo/xxh3` from `v1.0.2` to `v1.1.0` in `go.mod`/`go.sum`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 558a31dd28abdc7e42a41bcc350adc4aa2623d28. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->