### PR TITLE
Tim/fix/pipeline connection stage validation

### DIFF
--- a/docs/html/index.html
+++ b/docs/html/index.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8"/>
 <title>github.com/IrminData/irmin-sdk-go documentation</title>
 <h1>github.com/IrminData/irmin-sdk-go documentation</h1>
-<p>Generated on 2026-01-31 03:31 UTC</p>
+<p>Generated on 2026-02-02 11:55 UTC</p>
 <ul>
 <li><a href="github_com_IrminData_irmin-sdk-go.html">github.com/IrminData/irmin-sdk-go</a></li>
 <li><a href="github_com_IrminData_irmin-sdk-go_api.html">github.com/IrminData/irmin-sdk-go/api</a></li>

--- a/validator/domain_validators.go
+++ b/validator/domain_validators.go
@@ -129,9 +129,7 @@ func (v *Validator) validateActionPipelineStage(parentStruct reflect.Value) bool
 func (v *Validator) validateConnectionPipelineStage(parentStruct reflect.Value) bool {
 	connectionIDField := parentStruct.FieldByName("ConnectionID")
 	writeField := parentStruct.FieldByName("Write")
-	readField := parentStruct.FieldByName("Read")
 	writePathField := parentStruct.FieldByName("ConnectionWritePath")
-	readPathsField := parentStruct.FieldByName("ConnectionReadPaths")
 
 	// Connection stages must have a valid connection ID (validated as SQID)
 	if !v.validateResourceID(connectionIDField, "connections") {
@@ -146,33 +144,10 @@ func (v *Validator) validateConnectionPipelineStage(parentStruct reflect.Value) 
 		}
 	}
 
-	// If it's a read stage, must have read paths
-	if readField.IsValid() && readField.Bool() {
-		return v.validateReadPaths(readPathsField)
-	}
+	// Read paths are optional - empty paths means "read from root" which is valid
+	// The field can be nil, empty, or populated with specific paths
 
 	return true
-}
-
-// validateReadPaths validates that a read paths field is non-empty.
-// Handles both direct slices and pointers to slices.
-func (v *Validator) validateReadPaths(readPathsField reflect.Value) bool {
-	if !readPathsField.IsValid() {
-		return false
-	}
-
-	// Handle pointer to slice: dereference before checking length
-	var pathsLen int
-	if readPathsField.Kind() == reflect.Pointer {
-		if readPathsField.IsNil() {
-			return false
-		}
-		pathsLen = readPathsField.Elem().Len()
-	} else {
-		pathsLen = readPathsField.Len()
-	}
-
-	return pathsLen > 0
 }
 
 // validateRepositoryPipelineStage validates repository-type pipeline stages.

--- a/validator/validator.go
+++ b/validator/validator.go
@@ -398,18 +398,35 @@ func (v *Validator) buildValidationResult(err error) *ValidationResultError {
 }
 
 // getFieldName extracts a user-friendly field name from a validation error.
+// It uses the full namespace to show nested field paths (e.g., "workflowable.type" instead of just "type").
 func (v *Validator) getFieldName(fieldError validator.FieldError) string {
-	fieldName := fieldError.Field()
+	// Use Namespace() to get the full field path with JSON tag names
+	namespace := fieldError.Namespace()
 
-	// Convert PascalCase to snake_case for better readability
-	result := make([]rune, 0, len(fieldName)+FieldNameConversionBuffer)
-	for i, r := range fieldName {
+	// Remove the root struct name (first segment before the first dot)
+	// e.g., "Workflow.Workflowable.Type" -> "Workflowable.Type"
+	if idx := strings.Index(namespace, "."); idx != -1 {
+		namespace = namespace[idx+1:]
+	}
+
+	// Convert each segment from PascalCase to snake_case
+	segments := strings.Split(namespace, ".")
+	for i, segment := range segments {
+		segments[i] = v.toSnakeCase(segment)
+	}
+
+	return strings.Join(segments, ".")
+}
+
+// toSnakeCase converts a PascalCase string to snake_case.
+func (v *Validator) toSnakeCase(s string) string {
+	result := make([]rune, 0, len(s)+FieldNameConversionBuffer)
+	for i, r := range s {
 		if i > 0 && 'A' <= r && r <= 'Z' {
 			result = append(result, '_')
 		}
 		result = append(result, r)
 	}
-
 	return strings.ToLower(string(result))
 }
 

--- a/validator/validator_test.go
+++ b/validator/validator_test.go
@@ -1037,8 +1037,8 @@ func TestValidator_ValidateWorkflowable(t *testing.T) {
 		}
 	})
 
-	// Test invalid pipeline workflowable - missing stages
-	t.Run("invalid pipeline workflowable - missing stages", func(t *testing.T) {
+	// Test valid pipeline workflowable - empty stages is allowed (pipeline being configured)
+	t.Run("valid pipeline workflowable - empty stages", func(t *testing.T) {
 		connectionID, _ := sqidManager.Encode("connections", 123)
 		scriptID, _ := sqidManager.Encode("scripts", 123)
 		resultsRepository := "results-repo"
@@ -1046,8 +1046,9 @@ func TestValidator_ValidateWorkflowable(t *testing.T) {
 		resultsRepositoryPath := "/results"
 
 		workflowable := models.Workflowable{
-			Type: models.WorkflowableTypePipeline,
-			// Missing Stages
+			Type:   models.WorkflowableTypePipeline,
+			Stages: []models.PipelineStage{}, // Empty stages is valid - pipeline being configured
+			// Provide other fields for completeness
 			ConnectionID:            connectionID,
 			Repository:              "dummy-repo",
 			RepositoryBranch:        "main",
@@ -1060,8 +1061,8 @@ func TestValidator_ValidateWorkflowable(t *testing.T) {
 		}
 
 		err := validator.Validate(workflowable)
-		if err == nil {
-			t.Error("Expected validation error for pipeline workflowable with missing stages")
+		if err != nil {
+			t.Errorf("Expected valid pipeline workflowable with empty stages, got error: %v", err)
 		}
 	})
 
@@ -1250,8 +1251,8 @@ func TestValidator_ValidateWorkflowable(t *testing.T) {
 		}
 	})
 
-	// Test invalid export workflowable - missing field mappings
-	t.Run("invalid export workflowable - missing field mappings", func(t *testing.T) {
+	// Test valid export workflowable - empty field mappings is allowed (export data as-is)
+	t.Run("valid export workflowable - empty field mappings", func(t *testing.T) {
 		connectionID, _ := sqidManager.Encode("connections", 123)
 		scriptID, _ := sqidManager.Encode("scripts", 123)
 		resultsRepository := "results-repo"
@@ -1259,8 +1260,9 @@ func TestValidator_ValidateWorkflowable(t *testing.T) {
 		resultsRepositoryPath := "/results"
 
 		workflowable := models.Workflowable{
-			Type: models.WorkflowableTypeExport,
-			// Missing FieldMappings
+			Type:          models.WorkflowableTypeExport,
+			FieldMappings: []models.FieldMapping{}, // Empty field mappings is valid - export as-is
+			// Provide other required fields
 			ConnectionID:              connectionID,
 			Repository:                "my-repo",
 			RepositoryBranch:          "main",
@@ -1274,8 +1276,8 @@ func TestValidator_ValidateWorkflowable(t *testing.T) {
 		}
 
 		err := validator.Validate(workflowable)
-		if err == nil {
-			t.Error("Expected validation error for export workflowable with missing field mappings")
+		if err != nil {
+			t.Errorf("Expected valid export workflowable with empty field mappings, got error: %v", err)
 		}
 	})
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Validation behavior changes (connection stage read paths, export field mappings, pipeline stages) may allow previously-rejected payloads and alter client-visible error keys/messages, so downstream consumers should be verified.
> 
> **Overview**
> Relaxes connection-stage validation by no longer requiring `ConnectionReadPaths` when `Read` is true (treating nil/empty as “read from root”), removing the now-unused `validateReadPaths` helper.
> 
> Improves validation error reporting by emitting full nested field paths (dot-separated) instead of only the leaf field name, factoring out a `toSnakeCase` helper.
> 
> Updates tests to reflect newly-allowed configurations: pipeline workflowables may have empty `Stages`, and export workflowables may have empty `FieldMappings` (export data as-is).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0d2baee8b72b3cae98c69c7e4a4a764b09d9a697. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->