### PR TITLE
Tim/feat/validtoolname validator

### DIFF
--- a/docs/html/index.html
+++ b/docs/html/index.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8"/>
 <title>github.com/IrminData/irmin-sdk-go documentation</title>
 <h1>github.com/IrminData/irmin-sdk-go documentation</h1>
-<p>Generated on 2026-02-05 23:19 UTC</p>
+<p>Generated on 2026-02-06 23:01 UTC</p>
 <ul>
 <li><a href="github_com_IrminData_irmin-sdk-go.html">github.com/IrminData/irmin-sdk-go</a></li>
 <li><a href="github_com_IrminData_irmin-sdk-go_api.html">github.com/IrminData/irmin-sdk-go/api</a></li>

--- a/validator/custom_validators.go
+++ b/validator/custom_validators.go
@@ -436,6 +436,52 @@ func validateImageURL(fl validator.FieldLevel) bool {
 	return true
 }
 
+// validateToolName validates tool name format.
+// Tool names must:
+// - Be at least 1 character
+// - Contain only lowercase alphanumeric characters and underscores
+// - Start with a lowercase letter.
+func validateToolName(fl validator.FieldLevel) bool {
+	field := fl.Field()
+
+	// Handle nil pointers
+	if field.Kind() == reflect.Ptr && field.IsNil() {
+		return true
+	}
+
+	// Get the actual string value
+	var name string
+	if field.Kind() == reflect.Ptr {
+		name = field.Elem().String()
+	} else {
+		name = field.String()
+	}
+
+	// Must be at least 1 character
+	if len(name) == 0 {
+		return false
+	}
+
+	// Must start with a lowercase letter
+	first := name[0]
+	if first < 'a' || first > 'z' {
+		return false
+	}
+
+	// Check that the name contains only lowercase alphanumeric characters and underscores
+	for _, char := range name {
+		isLowerAlpha := char >= 'a' && char <= 'z'
+		isDigit := char >= '0' && char <= '9'
+		isUnderscore := char == '_'
+
+		if !isLowerAlpha && !isDigit && !isUnderscore {
+			return false
+		}
+	}
+
+	return true
+}
+
 // validateScheduleTrigger validates schedule trigger configuration.
 func validateScheduleTrigger(fl validator.FieldLevel) bool {
 	// Get the parent struct (ScheduleTrigger) from the Type field

--- a/validator/validator.go
+++ b/validator/validator.go
@@ -128,6 +128,9 @@ func registerValidations(v *validator.Validate, validator *Validator) {
 	if err := v.RegisterValidation("validphone", validatePhone); err != nil {
 		panic(err)
 	}
+	if err := v.RegisterValidation("validtoolname", validateToolName); err != nil {
+		panic(err)
+	}
 
 	// Register custom pipeline stage validation
 	if err := v.RegisterValidation("validpipelinestage", validator.validatePipelineStage); err != nil {
@@ -495,6 +498,11 @@ func (v *Validator) getCustomValidationMessage(field, tag string) (string, bool)
 		return fmt.Sprintf("%s must be a valid phone number", field), true
 	case "validimageurl":
 		return fmt.Sprintf("%s must be a valid image URL", field), true
+	case "validtoolname":
+		return fmt.Sprintf(
+			"%s must contain only lowercase letters, numbers, and underscores, and start with a letter",
+			field,
+		), true
 	case "validpipelinestage":
 		return fmt.Sprintf("%s must have valid configuration for its type", field), true
 	case "validworkflowable":


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small, additive validation change; primary risk is newly rejecting previously-accepted tool names where the new tag is applied.
> 
> **Overview**
> Adds a new `validtoolname` validation tag that enforces tool names start with a lowercase letter and contain only lowercase letters, digits, and underscores (nil pointers still treated as valid).
> 
> Registers the validator and wires in a corresponding user-facing error message in `getCustomValidationMessage`, so validation failures surface consistently through existing error formatting.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 709c9c3ed9d33f4a74c5983ef857460ba4881d21. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->