### PR TITLE
Tim/chore/clearer client errors

### DIFF
--- a/api/ai-app-client.go
+++ b/api/ai-app-client.go
@@ -113,7 +113,7 @@ func (c *AIAppClient) Request(ctx context.Context, opts AIAppRequestOptions) ([]
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, fmt.Errorf("API request failed with status %d. Body: %s", resp.StatusCode, responseBody)
+		return nil, &APIError{StatusCode: resp.StatusCode, Body: string(responseBody)}
 	}
 
 	return responseBody, nil

--- a/api/client.go
+++ b/api/client.go
@@ -262,10 +262,10 @@ func (c *Client) Request(ctx context.Context, opts RequestOptions) ([]byte, erro
 	// Check response status
 	if len(opts.AllowedStatus) == 0 {
 		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-			return nil, fmt.Errorf("API request failed with status %d. Body: %s", resp.StatusCode, responseBody)
+			return nil, &APIError{StatusCode: resp.StatusCode, Body: string(responseBody)}
 		}
 	} else if !slices.Contains(opts.AllowedStatus, resp.StatusCode) {
-		return nil, fmt.Errorf("API request failed with status %d. Body: %s", resp.StatusCode, responseBody)
+		return nil, &APIError{StatusCode: resp.StatusCode, Body: string(responseBody)}
 	}
 
 	return responseBody, nil

--- a/api/errors.go
+++ b/api/errors.go
@@ -1,0 +1,15 @@
+package irmincore
+
+import "fmt"
+
+// APIError is returned when the Irmin API responds with a non-success HTTP status code.
+// Use errors.As to extract it from wrapped errors.
+type APIError struct {
+	StatusCode int
+	Body       string
+}
+
+// Error implements the error interface.
+func (e *APIError) Error() string {
+	return fmt.Sprintf("API request failed with status %d. Body: %s", e.StatusCode, e.Body)
+}

--- a/docs/docs.md
+++ b/docs/docs.md
@@ -167,6 +167,8 @@ import "github.com/IrminData/irmin-sdk-go/api"
 - [type AIAppSystemPrompt](<#AIAppSystemPrompt>)
 - [type AIAppWriteFileRequest](<#AIAppWriteFileRequest>)
 - [type AIAppWriteResult](<#AIAppWriteResult>)
+- [type APIError](<#APIError>)
+  - [func \(e \*APIError\) Error\(\) string](<#APIError.Error>)
 - [type Client](<#Client>)
   - [func NewClient\(baseURL, token, locale string\) \*Client](<#NewClient>)
   - [func NewClientWithSQIDManager\(baseURL, token, locale string, sqidManager \*irminsqids.SQIDManager\) \*Client](<#NewClientWithSQIDManager>)
@@ -753,6 +755,27 @@ type AIAppWriteResult struct {
     RequiresApproval bool    `json:"requires_approval"    example:"false"`
 }
 ```
+
+<a name="APIError"></a>
+## type APIError
+
+APIError is returned when the Irmin API responds with a non\-success HTTP status code. Use errors.As to extract it from wrapped errors.
+
+```go
+type APIError struct {
+    StatusCode int
+    Body       string
+}
+```
+
+<a name="APIError.Error"></a>
+### func \(\*APIError\) Error
+
+```go
+func (e *APIError) Error() string
+```
+
+Error implements the error interface.
 
 <a name="Client"></a>
 ## type Client

--- a/docs/html/github_com_IrminData_irmin-sdk-go_api.html
+++ b/docs/html/github_com_IrminData_irmin-sdk-go_api.html
@@ -227,6 +227,16 @@ type AIAppWriteResult struct {
 }
     AIAppWriteResult represents the result of a write operation.
 
+type APIError struct {
+	StatusCode int
+	Body       string
+}
+    APIError is returned when the Irmin API responds with a non-success HTTP
+    status code. Use errors.As to extract it from wrapped errors.
+
+func (e *APIError) Error() string
+    Error implements the error interface.
+
 type Client struct {
 	// BaseURL is your Irmin Core API base: e.g. "https://api.irmin.co/api"
 	BaseURL string

--- a/docs/html/index.html
+++ b/docs/html/index.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8"/>
 <title>github.com/IrminData/irmin-sdk-go documentation</title>
 <h1>github.com/IrminData/irmin-sdk-go documentation</h1>
-<p>Generated on 2026-02-10 14:10 UTC</p>
+<p>Generated on 2026-02-13 09:12 UTC</p>
 <ul>
 <li><a href="github_com_IrminData_irmin-sdk-go.html">github.com/IrminData/irmin-sdk-go</a></li>
 <li><a href="github_com_IrminData_irmin-sdk-go_api.html">github.com/IrminData/irmin-sdk-go/api</a></li>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: changes error type returned on HTTP failures, which may affect callers that string-match errors but does not change request behavior.
> 
> **Overview**
> API clients now return a structured `APIError` (with `StatusCode` and response `Body`) instead of a formatted string error when the server responds with a non-success HTTP status.
> 
> This change is applied consistently across both `Client.Request` and `AIAppClient.Request`, and introduces the new `api/errors.go` definition to enable callers to inspect failures via `errors.As`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c157e1c139ddb70549e14c33c4ebd7ae6ecbfbc2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->