### PR TITLE
Tim/feat/add language preferences to the user model

### DIFF
--- a/api/profile.go
+++ b/api/profile.go
@@ -17,6 +17,7 @@ type UpdateProfileRequest struct {
 	Email     *string `json:"email,omitempty"      validate:"omitnil,email"      example:"john.doe@example.com"`
 	Phone     *string `json:"phone,omitempty"      validate:"omitnil,validphone" example:"+1234567890"`
 	Company   *string `json:"company,omitempty"    validate:"omitnil,max=100"    example:"Irmin"`
+	Language  *string `json:"language,omitempty"   validate:"omitnil,max=5"      example:"en"`
 }
 
 func (c *Client) GetProfile(ctx context.Context) (*irminmodels.User, *irminmodels.IrminAPIResponse, error) {
@@ -33,7 +34,7 @@ func (c *Client) GetProfile(ctx context.Context) (*irminmodels.User, *irminmodel
 
 func (c *Client) UpdateProfile(
 	ctx context.Context,
-	firstName, lastName, email, phone, company *string,
+	firstName, lastName, email, phone, company, language *string,
 	profilePicture *os.File,
 ) (*irminmodels.User, *irminmodels.IrminAPIResponse, error) {
 	// Create update request struct with only non-empty fields
@@ -52,6 +53,9 @@ func (c *Client) UpdateProfile(
 	}
 	if company != nil && *company != "" {
 		updateReq.Company = company
+	}
+	if language != nil && *language != "" {
+		updateReq.Language = language
 	}
 
 	var updatedProfile irminmodels.User

--- a/docs/docs.md
+++ b/docs/docs.md
@@ -330,7 +330,7 @@ import "github.com/IrminData/irmin-sdk-go/api"
   - [func \(c \*Client\) UpdateEmbeddingPriority\(ctx context.Context, workspace, repository string, req UpdateEmbeddingPriorityRequest\) \(\*irminmodels.IrminAPIResponse, error\)](<#Client.UpdateEmbeddingPriority>)
   - [func \(c \*Client\) UpdateInvite\(ctx context.Context, inviteID string, req UpdateInviteRequest\) \(\*irminmodels.Invite, \*irminmodels.IrminAPIResponse, error\)](<#Client.UpdateInvite>)
   - [func \(c \*Client\) UpdatePolicy\(ctx context.Context, workspace, policyID string, req UpdatePolicyRequest\) \(\*irminmodels.Policy, \*irminmodels.IrminAPIResponse, error\)](<#Client.UpdatePolicy>)
-  - [func \(c \*Client\) UpdateProfile\(ctx context.Context, firstName, lastName, email, phone, company \*string, profilePicture \*os.File\) \(\*irminmodels.User, \*irminmodels.IrminAPIResponse, error\)](<#Client.UpdateProfile>)
+  - [func \(c \*Client\) UpdateProfile\(ctx context.Context, firstName, lastName, email, phone, company, language \*string, profilePicture \*os.File\) \(\*irminmodels.User, \*irminmodels.IrminAPIResponse, error\)](<#Client.UpdateProfile>)
   - [func \(c \*Client\) UpdateRegisteredConnector\(ctx context.Context, connectorID string, req ConnectorRequest\) \(\*irminmodels.Connector, \*irminmodels.IrminAPIResponse, error\)](<#Client.UpdateRegisteredConnector>)
   - [func \(c \*Client\) UpdateRepository\(ctx context.Context, workspace, slug string, req UpdateRepositoryRequest\) \(\*irminmodels.Repository, \*irminmodels.IrminAPIResponse, error\)](<#Client.UpdateRepository>)
   - [func \(c \*Client\) UpdateStoredQuery\(ctx context.Context, workspace, queryID string, req UpdateQueryRequest\) \(\*irminmodels.StoredQuery, \*irminmodels.IrminAPIResponse, error\)](<#Client.UpdateStoredQuery>)
@@ -2279,7 +2279,7 @@ UpdatePolicy updates an existing policy.
 ### func \(\*Client\) UpdateProfile
 
 ```go
-func (c *Client) UpdateProfile(ctx context.Context, firstName, lastName, email, phone, company *string, profilePicture *os.File) (*irminmodels.User, *irminmodels.IrminAPIResponse, error)
+func (c *Client) UpdateProfile(ctx context.Context, firstName, lastName, email, phone, company, language *string, profilePicture *os.File) (*irminmodels.User, *irminmodels.IrminAPIResponse, error)
 ```
 
 
@@ -2729,9 +2729,9 @@ CreateSignedURLRequest represents the JSON request body for creating a signed do
 
 ```go
 type CreateSignedURLRequest struct {
-    Path           string `json:"path"                       validate:"required"                example:"data/file.csv"`
-    Ref            string `json:"ref,omitempty"                                                 example:"main"`
-    ExpiresInHours int    `json:"expires_in_hours,omitempty" validate:"omitempty,min=1,max=168" example:"24"`
+    Path           string `json:"path"                       validate:"required"        example:"data/file.csv"`
+    Ref            string `json:"ref,omitempty"                                         example:"main"`
+    ExpiresInHours *int   `json:"expires_in_hours,omitempty" validate:"omitempty,min=0" example:"24"`
 }
 ```
 
@@ -3293,6 +3293,7 @@ type UpdateProfileRequest struct {
     Email     *string `json:"email,omitempty"      validate:"omitnil,email"      example:"john.doe@example.com"`
     Phone     *string `json:"phone,omitempty"      validate:"omitnil,validphone" example:"+1234567890"`
     Company   *string `json:"company,omitempty"    validate:"omitnil,max=100"    example:"Irmin"`
+    Language  *string `json:"language,omitempty"   validate:"omitnil,max=5"      example:"en"`
 }
 ```
 
@@ -6049,7 +6050,7 @@ type StoredQuery struct {
 type StoredScript struct {
     ID          string    `json:"id"                    validate:"required,validsqid=scripts" example:"scr_8x2m9k4n7p5q"`
     Name        string    `json:"name"                  validate:"required,max=255"           example:"script.py"`
-    Description *string   `json:"description,omitempty" validate:"max=500"                    example:"Data processor for the project"`
+    Description *string   `json:"description,omitempty" validate:"omitempty,max=500"          example:"Data processor for the project"`
     Content     *string   `json:"content,omitempty"                                           example:"This is the content of the file"`
     Language    *string   `json:"language,omitempty"                                          example:"js"` // js, py, go, etc.
     Owner       User      `json:"owner"                 validate:"required"`
@@ -6279,6 +6280,7 @@ type User struct {
     Email          string `json:"email"           validate:"required,email"           example:"john.doe@example.com"`
     Phone          string `json:"phone"           validate:"validphone"               example:"+1-555-0123"`
     Company        string `json:"company"         validate:"max=100"                  example:"Acme Corp"`
+    Language       string `json:"language"        validate:"max=5"                    example:"en"`
     ProfilePicture string `json:"profile_picture" validate:"validimageurl"            example:"https://avatars.example.com/john-doe.jpg"`
     Roles          []Role `json:"roles"           validate:"dive"`
 }

--- a/docs/html/github_com_IrminData_irmin-sdk-go_api.html
+++ b/docs/html/github_com_IrminData_irmin-sdk-go_api.html
@@ -1217,7 +1217,7 @@ func (c *Client) UpdatePolicy(
 
 func (c *Client) UpdateProfile(
 	ctx context.Context,
-	firstName, lastName, email, phone, company *string,
+	firstName, lastName, email, phone, company, language *string,
 	profilePicture *os.File,
 ) (*irminmodels.User, *irminmodels.IrminAPIResponse, error)
 
@@ -1521,9 +1521,9 @@ type CreateScriptRequest struct {
     CreateScriptRequest represents the JSON request body for creating a script.
 
 type CreateSignedURLRequest struct {
-	Path           string `json:"path"                       validate:"required"                example:"data/file.csv"`
-	Ref            string `json:"ref,omitempty"                                                 example:"main"`
-	ExpiresInHours int    `json:"expires_in_hours,omitempty" validate:"omitempty,min=1,max=168" example:"24"`
+	Path           string `json:"path"                       validate:"required"        example:"data/file.csv"`
+	Ref            string `json:"ref,omitempty"                                         example:"main"`
+	ExpiresInHours *int   `json:"expires_in_hours,omitempty" validate:"omitempty,min=0" example:"24"`
 }
     CreateSignedURLRequest represents the JSON request body for creating a
     signed download URL.
@@ -1864,6 +1864,7 @@ type UpdateProfileRequest struct {
 	Email     *string `json:"email,omitempty"      validate:"omitnil,email"      example:"john.doe@example.com"`
 	Phone     *string `json:"phone,omitempty"      validate:"omitnil,validphone" example:"+1234567890"`
 	Company   *string `json:"company,omitempty"    validate:"omitnil,max=100"    example:"Irmin"`
+	Language  *string `json:"language,omitempty"   validate:"omitnil,max=5"      example:"en"`
 }
     UpdateProfileRequest represents the JSON request body for updating profile.
 

--- a/docs/html/github_com_IrminData_irmin-sdk-go_models.html
+++ b/docs/html/github_com_IrminData_irmin-sdk-go_models.html
@@ -1348,7 +1348,7 @@ type StoredQuery struct {
 type StoredScript struct {
 	ID          string    `json:"id"                    validate:"required,validsqid=scripts" example:"scr_8x2m9k4n7p5q"`
 	Name        string    `json:"name"                  validate:"required,max=255"           example:"script.py"`
-	Description *string   `json:"description,omitempty" validate:"max=500"                    example:"Data processor for the project"`
+	Description *string   `json:"description,omitempty" validate:"omitempty,max=500"          example:"Data processor for the project"`
 	Content     *string   `json:"content,omitempty"                                           example:"This is the content of the file"`
 	Language    *string   `json:"language,omitempty"                                          example:"js"` // js, py, go, etc.
 	Owner       User      `json:"owner"                 validate:"required"`
@@ -1473,6 +1473,7 @@ type User struct {
 	Email          string `json:"email"           validate:"required,email"           example:"john.doe@example.com"`
 	Phone          string `json:"phone"           validate:"validphone"               example:"+1-555-0123"`
 	Company        string `json:"company"         validate:"max=100"                  example:"Acme Corp"`
+	Language       string `json:"language"        validate:"max=5"                    example:"en"`
 	ProfilePicture string `json:"profile_picture" validate:"validimageurl"            example:"https://avatars.example.com/john-doe.jpg"`
 	Roles          []Role `json:"roles"           validate:"dive"`
 }

--- a/docs/html/index.html
+++ b/docs/html/index.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8"/>
 <title>github.com/IrminData/irmin-sdk-go documentation</title>
 <h1>github.com/IrminData/irmin-sdk-go documentation</h1>
-<p>Generated on 2026-02-14 16:26 UTC</p>
+<p>Generated on 2026-02-24 18:02 UTC</p>
 <ul>
 <li><a href="github_com_IrminData_irmin-sdk-go.html">github.com/IrminData/irmin-sdk-go</a></li>
 <li><a href="github_com_IrminData_irmin-sdk-go_api.html">github.com/IrminData/irmin-sdk-go/api</a></li>

--- a/models/user.go
+++ b/models/user.go
@@ -1,12 +1,13 @@
 package irminmodels
 
 type User struct {
-	ID               string `json:"id"                 validate:"required,validsqid=users" example:"usr_2k8n9q1m7p3x4z"`
-	FirstName        string `json:"first_name"         validate:"required,max=50"          example:"John"`
-	LastName         string `json:"last_name"          validate:"required,max=50"          example:"Doe"`
-	Email            string `json:"email"              validate:"required,email"           example:"john.doe@example.com"`
-	Phone            string `json:"phone"              validate:"validphone"               example:"+1-555-0123"`
-	Company          string `json:"company"            validate:"max=100"                  example:"Acme Corp"`
-	ProfilePicture string `json:"profile_picture" validate:"validimageurl" example:"https://avatars.example.com/john-doe.jpg"`
+	ID             string `json:"id"              validate:"required,validsqid=users" example:"usr_2k8n9q1m7p3x4z"`
+	FirstName      string `json:"first_name"      validate:"required,max=50"          example:"John"`
+	LastName       string `json:"last_name"       validate:"required,max=50"          example:"Doe"`
+	Email          string `json:"email"           validate:"required,email"           example:"john.doe@example.com"`
+	Phone          string `json:"phone"           validate:"validphone"               example:"+1-555-0123"`
+	Company        string `json:"company"         validate:"max=100"                  example:"Acme Corp"`
+	Language       string `json:"language"        validate:"max=5"                    example:"en"`
+	ProfilePicture string `json:"profile_picture" validate:"validimageurl"            example:"https://avatars.example.com/john-doe.jpg"`
 	Roles          []Role `json:"roles"           validate:"dive"`
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Introduces a new `language` field to the user/profile contract and changes the `UpdateProfile` client method signature, which may break existing callers and requires server compatibility for the new attribute.
> 
> **Overview**
> Adds support for persisting a user language preference by introducing `language` on the `User` model and including it in profile update payloads.
> 
> Updates `UpdateProfileRequest` and the `Client.UpdateProfile` method to accept an optional `language` parameter (validated `max=5`) and send it via both JSON and multipart `metadata` update flows.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ac9391440d826be6efcd874fb09b89ef74e80e2f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->