### PR TITLE
Tim/feat/unify mime type detection

### DIFF
--- a/docs/docs.md
+++ b/docs/docs.md
@@ -6747,7 +6747,7 @@ GetInputFile reads a file from the \_input directory. Returns the file content a
 func IsBinaryMimeType(contentType string) bool
 ```
 
-IsBinaryMimeType checks if the given MIME type represents binary data.
+IsBinaryMimeType checks if the given MIME type represents binary data. SVG \(image/svg\+xml\) is excluded since it is a text\-based XML format.
 
 <a name="IsStructuredDataFormat"></a>
 ## func IsStructuredDataFormat

--- a/docs/docs.md
+++ b/docs/docs.md
@@ -3623,7 +3623,7 @@ EscapeSQLString escapes single quotes in SQL string literals by doubling them. T
 func GetContentTypeFromExtension(extension string) string
 ```
 
-GetContentTypeFromExtension returns the MIME type for a given file extension. It delegates to the SDK's GetContentTypeHybrid which handles both specialized data analytics formats and standard MIME type detection.
+GetContentTypeFromExtension returns the MIME type for a given file extension.
 
 <a name="GetRequiredExtensions"></a>
 ## func GetRequiredExtensions
@@ -6652,13 +6652,16 @@ import "github.com/IrminData/irmin-sdk-go/utils"
 
 ## Index
 
-- [func AutoDetectMimeType\(filename string\) string](<#AutoDetectMimeType>)
 - [func CreateMultipartForm\(file \*File, fieldName string\) \(\*bytes.Buffer, string, error\)](<#CreateMultipartForm>)
 - [func CreateMultipartFormWithFields\(file \*File, fieldName string, textFields map\[string\]string\) \(\*bytes.Buffer, string, error\)](<#CreateMultipartFormWithFields>)
+- [func DetectMimeType\(content \[\]byte, filename string\) string](<#DetectMimeType>)
+- [func DetectMimeTypeByExtension\(filename string\) string](<#DetectMimeTypeByExtension>)
+- [func DetectMimeTypeFromReader\(r io.Reader, filename string\) \(string, error\)](<#DetectMimeTypeFromReader>)
 - [func GetAPIFromFlags\(\) \(string, string, error\)](<#GetAPIFromFlags>)
-- [func GetContentTypeHybrid\(ext string\) string](<#GetContentTypeHybrid>)
 - [func GetInputFile\(filePath string\) \(\[\]byte, error\)](<#GetInputFile>)
+- [func IsBinaryMimeType\(contentType string\) bool](<#IsBinaryMimeType>)
 - [func IsStructuredDataFormat\(ext, contentType string\) bool](<#IsStructuredDataFormat>)
+- [func IsTextMimeType\(mimeType string\) bool](<#IsTextMimeType>)
 - [func ListInputFiles\(\) \(\[\]string, error\)](<#ListInputFiles>)
 - [func SendComputeResult\(data \[\]byte, fileName string\) error](<#SendComputeResult>)
 - [func StripMimeTypeParameters\(mimeType string\) string](<#StripMimeTypeParameters>)
@@ -6673,15 +6676,6 @@ import "github.com/IrminData/irmin-sdk-go/utils"
 - [type ObjectDetails](<#ObjectDetails>)
   - [func ParseObjectDetailsFromPath\(inputPath string\) ObjectDetails](<#ParseObjectDetailsFromPath>)
 
-
-<a name="AutoDetectMimeType"></a>
-## func AutoDetectMimeType
-
-```go
-func AutoDetectMimeType(filename string) string
-```
-
-AutoDetectMimeType detects MIME type from filename extension.
 
 <a name="CreateMultipartForm"></a>
 ## func CreateMultipartForm
@@ -6701,6 +6695,33 @@ func CreateMultipartFormWithFields(file *File, fieldName string, textFields map[
 
 CreateMultipartFormWithFields creates multipart form with additional text fields.
 
+<a name="DetectMimeType"></a>
+## func DetectMimeType
+
+```go
+func DetectMimeType(content []byte, filename string) string
+```
+
+DetectMimeType detects MIME type using both content \(magic bytes\) and filename extension. It checks specialized extension mappings first, then uses the mimetype library for content\-based detection, and falls back to system extension mapping.
+
+<a name="DetectMimeTypeByExtension"></a>
+## func DetectMimeTypeByExtension
+
+```go
+func DetectMimeTypeByExtension(filename string) string
+```
+
+DetectMimeTypeByExtension detects MIME type from filename extension only. It checks specialized data analytics format mappings first, then falls back to the system's built\-in MIME type database.
+
+<a name="DetectMimeTypeFromReader"></a>
+## func DetectMimeTypeFromReader
+
+```go
+func DetectMimeTypeFromReader(r io.Reader, filename string) (string, error)
+```
+
+DetectMimeTypeFromReader detects MIME type from an io.Reader and filename. The mimetype library internally reads only the first 3072 bytes from the reader. Note: the reader will be partially consumed after this call.
+
 <a name="GetAPIFromFlags"></a>
 ## func GetAPIFromFlags
 
@@ -6709,17 +6730,6 @@ func GetAPIFromFlags() (string, string, error)
 ```
 
 GetAPIFromFlags retrieves the API key and the base URL from command line flags.
-
-<a name="GetContentTypeHybrid"></a>
-## func GetContentTypeHybrid
-
-```go
-func GetContentTypeHybrid(ext string) string
-```
-
-GetContentTypeHybrid uses a hybrid approach for MIME type detection. It first checks for specialized data analytics formats that aren't typically registered in system MIME databases, then falls back to the system's built\-in MIME type detection for standard formats.
-
-To maintain backward compatibility with existing tests, this function: \- Uses specialized mappings for data analytics formats \- Falls back to system MIME types but strips charset parameters \- Maintains specific legacy MIME types where expected by existing code
 
 <a name="GetInputFile"></a>
 ## func GetInputFile
@@ -6730,6 +6740,15 @@ func GetInputFile(filePath string) ([]byte, error)
 
 GetInputFile reads a file from the \_input directory. Returns the file content as bytes and any error encountered.
 
+<a name="IsBinaryMimeType"></a>
+## func IsBinaryMimeType
+
+```go
+func IsBinaryMimeType(contentType string) bool
+```
+
+IsBinaryMimeType checks if the given MIME type represents binary data.
+
 <a name="IsStructuredDataFormat"></a>
 ## func IsStructuredDataFormat
 
@@ -6738,6 +6757,15 @@ func IsStructuredDataFormat(ext, contentType string) bool
 ```
 
 IsStructuredDataFormat determines if a file extension and MIME type represent structured data that can be queried, analyzed, or processed as tabular data.
+
+<a name="IsTextMimeType"></a>
+## func IsTextMimeType
+
+```go
+func IsTextMimeType(mimeType string) bool
+```
+
+IsTextMimeType checks if the given MIME type represents text\-based content suitable for display or processing as text.
 
 <a name="ListInputFiles"></a>
 ## func ListInputFiles
@@ -6764,7 +6792,7 @@ SendComputeResult writes the provided data to a file with the given name in the 
 func StripMimeTypeParameters(mimeType string) string
 ```
 
-StripMimeTypeParameters removes charset and other parameters from MIME types to maintain backward compatibility with existing test expectations.
+StripMimeTypeParameters removes charset and other parameters from MIME types. For example, "text/plain; charset=utf\-8" becomes "text/plain".
 
 <a name="UnzipFiles"></a>
 ## func UnzipFiles

--- a/docs/html/github_com_IrminData_irmin-sdk-go_duckdb.html
+++ b/docs/html/github_com_IrminData_irmin-sdk-go_duckdb.html
@@ -28,8 +28,7 @@ func EscapeSQLString(s string) string
 
 func GetContentTypeFromExtension(extension string) string
     GetContentTypeFromExtension returns the MIME type for a given file
-    extension. It delegates to the SDK's GetContentTypeHybrid which handles both
-    specialized data analytics formats and standard MIME type detection.
+    extension.
 
 func GetRequiredExtensions(options *ReadOptions) []string
     GetRequiredExtensions returns a list of required DuckDB extensions for the

--- a/docs/html/github_com_IrminData_irmin-sdk-go_utils.html
+++ b/docs/html/github_com_IrminData_irmin-sdk-go_utils.html
@@ -44,6 +44,7 @@ func GetInputFile(filePath string) ([]byte, error)
 
 func IsBinaryMimeType(contentType string) bool
     IsBinaryMimeType checks if the given MIME type represents binary data.
+    SVG (image/svg+xml) is excluded since it is a text-based XML format.
 
 func IsStructuredDataFormat(ext, contentType string) bool
     IsStructuredDataFormat determines if a file extension and MIME type

--- a/docs/html/github_com_IrminData_irmin-sdk-go_utils.html
+++ b/docs/html/github_com_IrminData_irmin-sdk-go_utils.html
@@ -7,9 +7,6 @@ package irminutils // import "github.com/IrminData/irmin-sdk-go/utils"
 
 FUNCTIONS
 
-func AutoDetectMimeType(filename string) string
-    AutoDetectMimeType detects MIME type from filename extension.
-
 func CreateMultipartForm(file *File, fieldName string) (*bytes.Buffer, string, error)
     CreateMultipartForm creates a complete multipart/form-data form.
 
@@ -21,29 +18,41 @@ func CreateMultipartFormWithFields(
     CreateMultipartFormWithFields creates multipart form with additional text
     fields.
 
+func DetectMimeType(content []byte, filename string) string
+    DetectMimeType detects MIME type using both content (magic bytes) and
+    filename extension. It checks specialized extension mappings first,
+    then uses the mimetype library for content-based detection, and falls back
+    to system extension mapping.
+
+func DetectMimeTypeByExtension(filename string) string
+    DetectMimeTypeByExtension detects MIME type from filename extension only.
+    It checks specialized data analytics format mappings first, then falls back
+    to the system's built-in MIME type database.
+
+func DetectMimeTypeFromReader(r io.Reader, filename string) (string, error)
+    DetectMimeTypeFromReader detects MIME type from an io.Reader and filename.
+    The mimetype library internally reads only the first 3072 bytes from the
+    reader. Note: the reader will be partially consumed after this call.
+
 func GetAPIFromFlags() (string, string, error)
     GetAPIFromFlags retrieves the API key and the base URL from command line
     flags.
-
-func GetContentTypeHybrid(ext string) string
-    GetContentTypeHybrid uses a hybrid approach for MIME type detection.
-    It first checks for specialized data analytics formats that aren't typically
-    registered in system MIME databases, then falls back to the system's
-    built-in MIME type detection for standard formats.
-
-    To maintain backward compatibility with existing tests, this function:
-    - Uses specialized mappings for data analytics formats - Falls back to
-    system MIME types but strips charset parameters - Maintains specific legacy
-    MIME types where expected by existing code
 
 func GetInputFile(filePath string) ([]byte, error)
     GetInputFile reads a file from the _input directory. Returns the file
     content as bytes and any error encountered.
 
+func IsBinaryMimeType(contentType string) bool
+    IsBinaryMimeType checks if the given MIME type represents binary data.
+
 func IsStructuredDataFormat(ext, contentType string) bool
     IsStructuredDataFormat determines if a file extension and MIME type
     represent structured data that can be queried, analyzed, or processed as
     tabular data.
+
+func IsTextMimeType(mimeType string) bool
+    IsTextMimeType checks if the given MIME type represents text-based content
+    suitable for display or processing as text.
 
 func ListInputFiles() ([]string, error)
     ListInputFiles returns a list of all files in the _input directory.
@@ -56,8 +65,8 @@ func SendComputeResult(data []byte, fileName string) error
     results back to the host system from within the container.
 
 func StripMimeTypeParameters(mimeType string) string
-    StripMimeTypeParameters removes charset and other parameters from MIME types
-    to maintain backward compatibility with existing test expectations.
+    StripMimeTypeParameters removes charset and other parameters from MIME
+    types. For example, "text/plain; charset=utf-8" becomes "text/plain".
 
 func UnzipFiles(zipData []byte) (map[string][]byte, error)
     UnzipFiles decompresses a ZIP archive from a byte slice into a map of file

--- a/docs/html/index.html
+++ b/docs/html/index.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8"/>
 <title>github.com/IrminData/irmin-sdk-go documentation</title>
 <h1>github.com/IrminData/irmin-sdk-go documentation</h1>
-<p>Generated on 2026-02-28 13:57 UTC</p>
+<p>Generated on 2026-02-28 14:12 UTC</p>
 <ul>
 <li><a href="github_com_IrminData_irmin-sdk-go.html">github.com/IrminData/irmin-sdk-go</a></li>
 <li><a href="github_com_IrminData_irmin-sdk-go_api.html">github.com/IrminData/irmin-sdk-go/api</a></li>

--- a/docs/html/index.html
+++ b/docs/html/index.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8"/>
 <title>github.com/IrminData/irmin-sdk-go documentation</title>
 <h1>github.com/IrminData/irmin-sdk-go documentation</h1>
-<p>Generated on 2026-02-27 12:27 UTC</p>
+<p>Generated on 2026-02-28 13:49 UTC</p>
 <ul>
 <li><a href="github_com_IrminData_irmin-sdk-go.html">github.com/IrminData/irmin-sdk-go</a></li>
 <li><a href="github_com_IrminData_irmin-sdk-go_api.html">github.com/IrminData/irmin-sdk-go/api</a></li>

--- a/docs/html/index.html
+++ b/docs/html/index.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8"/>
 <title>github.com/IrminData/irmin-sdk-go documentation</title>
 <h1>github.com/IrminData/irmin-sdk-go documentation</h1>
-<p>Generated on 2026-02-28 13:49 UTC</p>
+<p>Generated on 2026-02-28 13:57 UTC</p>
 <ul>
 <li><a href="github_com_IrminData_irmin-sdk-go.html">github.com/IrminData/irmin-sdk-go</a></li>
 <li><a href="github_com_IrminData_irmin-sdk-go_api.html">github.com/IrminData/irmin-sdk-go/api</a></li>

--- a/docs/html/index.html
+++ b/docs/html/index.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8"/>
 <title>github.com/IrminData/irmin-sdk-go documentation</title>
 <h1>github.com/IrminData/irmin-sdk-go documentation</h1>
-<p>Generated on 2026-02-28 14:12 UTC</p>
+<p>Generated on 2026-02-28 15:19 UTC</p>
 <ul>
 <li><a href="github_com_IrminData_irmin-sdk-go.html">github.com/IrminData/irmin-sdk-go</a></li>
 <li><a href="github_com_IrminData_irmin-sdk-go_api.html">github.com/IrminData/irmin-sdk-go/api</a></li>

--- a/duckdb/client.go
+++ b/duckdb/client.go
@@ -284,17 +284,11 @@ func IsStructuredFormat(extension string) bool {
 }
 
 // GetContentTypeFromExtension returns the MIME type for a given file extension.
-// It delegates to the SDK's GetContentTypeHybrid which handles both specialized
-// data analytics formats and standard MIME type detection.
 func GetContentTypeFromExtension(extension string) string {
-	// Normalize extension to include the dot prefix
 	ext := strings.ToLower(extension)
 	if !strings.HasPrefix(ext, ".") {
 		ext = "." + ext
 	}
 
-	// Use the SDK's hybrid MIME type detection
-	// This handles specialized data analytics formats (parquet, avro, delta, etc.)
-	// and falls back to Go's standard mime.TypeByExtension for common formats
-	return irminutils.GetContentTypeHybrid(ext)
+	return irminutils.DetectMimeTypeByExtension("file" + ext)
 }

--- a/go.mod
+++ b/go.mod
@@ -2,9 +2,10 @@ module github.com/IrminData/irmin-sdk-go
 
 go 1.25.0
 
+require github.com/gabriel-vasile/mimetype v1.4.13
+
 require (
 	github.com/apache/arrow-go/v18 v18.5.1 // indirect
-	github.com/gabriel-vasile/mimetype v1.4.13 // indirect
 	github.com/go-playground/locales v0.14.1 // indirect
 	github.com/go-playground/universal-translator v0.18.1 // indirect
 	github.com/go-viper/mapstructure/v2 v2.5.0 // indirect

--- a/utils/createFile.go
+++ b/utils/createFile.go
@@ -4,10 +4,8 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"mime"
 	"mime/multipart"
 	"os"
-	"path/filepath"
 	"time"
 )
 
@@ -50,16 +48,7 @@ func (f *File) MultipartFile() multipart.File {
 
 // MimeType returns the MIME type based on the filename extension.
 func (f *File) MimeType() string {
-	return AutoDetectMimeType(f.Filename)
-}
-
-// AutoDetectMimeType detects MIME type from filename extension.
-func AutoDetectMimeType(filename string) string {
-	ext := filepath.Ext(filename)
-	if mimeType := mime.TypeByExtension(ext); mimeType != "" {
-		return mimeType
-	}
-	return "application/octet-stream"
+	return DetectMimeTypeByExtension(f.Filename)
 }
 
 // fileWrapper implements multipart.File interface

--- a/utils/mimetype.go
+++ b/utils/mimetype.go
@@ -184,7 +184,8 @@ func IsBinaryMimeType(contentType string) bool {
 
 	if strings.HasPrefix(ct, "image/") ||
 		strings.HasPrefix(ct, "audio/") ||
-		strings.HasPrefix(ct, "video/") {
+		strings.HasPrefix(ct, "video/") ||
+		strings.HasPrefix(ct, "font/") {
 		return true
 	}
 

--- a/utils/mimetype.go
+++ b/utils/mimetype.go
@@ -1,0 +1,216 @@
+package irminutils
+
+import (
+	"io"
+	"mime"
+	"path/filepath"
+	"strings"
+
+	"github.com/gabriel-vasile/mimetype"
+)
+
+// specializedTypes maps file extensions to MIME types for formats that aren't
+// typically registered in system MIME databases (analytics, modern media, fonts).
+//
+//nolint:gochecknoglobals // Package-level lookup table for efficiency
+var specializedTypes = map[string]string{
+	// Advanced analytics formats
+	".parquet": "application/vnd.apache.parquet",
+	".avro":    "application/vnd.apache.avro",
+	".orc":     "application/vnd.apache.orc",
+	".delta":   "application/x-delta-lake",
+	".iceberg": "application/x-iceberg",
+
+	// Specialized text formats for data processing
+	".jsonl":  "application/jsonl",
+	".ndjson": "application/x-ndjson",
+	".tsv":    "text/tab-separated-values",
+	".tab":    "text/tab-separated-values",
+	".yaml":   "application/x-yaml",
+	".yml":    "application/x-yaml",
+
+	// Excel binary formats (might not be in all systems)
+	".xlsb": "application/vnd.ms-excel.sheet.binary.macroEnabled.12",
+	".xlsm": "application/vnd.ms-excel.sheet.macroEnabled.12",
+
+	// Modern image formats that may not be universally recognized
+	".heic": "image/heic",
+	".heif": "image/heif",
+	".avif": "image/avif",
+	".webp": "image/webp",
+
+	// Modern audio formats that may not be universally recognized
+	".opus": "audio/opus",
+	".flac": "audio/flac",
+
+	// Font formats that may not be universally recognized
+	".woff":  "font/woff",
+	".woff2": "font/woff2",
+	".otf":   "font/otf",
+	".ttf":   "font/ttf",
+
+	// Legacy overrides for backward compatibility
+	".js": "application/javascript",
+}
+
+// binaryApplicationTypes are application/* MIME types that represent binary data.
+//
+//nolint:gochecknoglobals // Package-level lookup table for efficiency
+var binaryApplicationTypes = map[string]bool{
+	// Documents
+	"application/pdf":    true,
+	"application/msword": true,
+	"application/vnd.openxmlformats-officedocument.wordprocessingml.document": true,
+	"application/vnd.ms-excel": true,
+	"application/vnd.openxmlformats-officedocument.spreadsheetml.sheet":         true,
+	"application/vnd.ms-powerpoint":                                             true,
+	"application/vnd.openxmlformats-officedocument.presentationml.presentation": true,
+
+	// Archives
+	"application/zip":     true,
+	"application/gzip":    true,
+	"application/x-tar":   true,
+	"application/x-rar":   true,
+	"application/x-7z":    true,
+	"application/x-bzip":  true,
+	"application/x-bzip2": true,
+
+	// Generic binary
+	defaultMimeType:        true,
+	"application/x-binary": true,
+}
+
+// textApplicationTypes are application/* MIME types that represent text-based content.
+//
+//nolint:gochecknoglobals // Package-level lookup table for efficiency
+var textApplicationTypes = map[string]bool{
+	"application/json":       true,
+	"application/ld+json":    true,
+	"application/xml":        true,
+	"application/xhtml+xml":  true,
+	"application/x-yaml":     true,
+	"application/yaml":       true,
+	"application/csv":        true,
+	"application/sql":        true,
+	"application/graphql":    true,
+	"application/javascript": true,
+	"application/ecmascript": true,
+	"application/x-latex":    true,
+	"application/x-sh":       true,
+	"application/x-toml":     true,
+	"application/x-ini":      true,
+}
+
+// DetectMimeType detects MIME type using both content (magic bytes) and filename extension.
+// It checks specialized extension mappings first, then uses the mimetype library for
+// content-based detection, and falls back to system extension mapping.
+func DetectMimeType(content []byte, filename string) string {
+	ext := strings.ToLower(filepath.Ext(filename))
+
+	// Specialized formats take priority (analytics, fonts, etc.)
+	if mimeType, exists := specializedTypes[ext]; exists {
+		return mimeType
+	}
+
+	// Content-based detection using mimetype library (reads first 3072 bytes)
+	if len(content) > 0 {
+		detected := mimetype.Detect(content)
+		if detected.String() != defaultMimeType {
+			return StripMimeTypeParameters(detected.String())
+		}
+	}
+
+	// Extension-based fallback via system MIME database
+	if ext != "" {
+		if mimeType := mime.TypeByExtension(ext); mimeType != "" {
+			return StripMimeTypeParameters(mimeType)
+		}
+	}
+
+	return defaultMimeType
+}
+
+// DetectMimeTypeByExtension detects MIME type from filename extension only.
+// It checks specialized data analytics format mappings first, then falls back
+// to the system's built-in MIME type database.
+func DetectMimeTypeByExtension(filename string) string {
+	ext := strings.ToLower(filepath.Ext(filename))
+
+	if mimeType, exists := specializedTypes[ext]; exists {
+		return mimeType
+	}
+
+	if ext != "" {
+		if mimeType := mime.TypeByExtension(ext); mimeType != "" {
+			return StripMimeTypeParameters(mimeType)
+		}
+	}
+
+	return defaultMimeType
+}
+
+// DetectMimeTypeFromReader detects MIME type from an io.Reader and filename.
+// The mimetype library internally reads only the first 3072 bytes from the reader.
+// Note: the reader will be partially consumed after this call.
+func DetectMimeTypeFromReader(r io.Reader, filename string) (string, error) {
+	ext := strings.ToLower(filepath.Ext(filename))
+
+	// Specialized formats take priority
+	if mimeType, exists := specializedTypes[ext]; exists {
+		return mimeType, nil
+	}
+
+	detected, err := mimetype.DetectReader(r)
+	if err != nil {
+		return defaultMimeType, err
+	}
+
+	if detected.String() != defaultMimeType {
+		return StripMimeTypeParameters(detected.String()), nil
+	}
+
+	if ext != "" {
+		if mimeType := mime.TypeByExtension(ext); mimeType != "" {
+			return StripMimeTypeParameters(mimeType), nil
+		}
+	}
+
+	return defaultMimeType, nil
+}
+
+// IsBinaryMimeType checks if the given MIME type represents binary data.
+func IsBinaryMimeType(contentType string) bool {
+	ct := StripMimeTypeParameters(strings.ToLower(contentType))
+
+	if strings.HasPrefix(ct, "image/") ||
+		strings.HasPrefix(ct, "audio/") ||
+		strings.HasPrefix(ct, "video/") {
+		return true
+	}
+
+	return binaryApplicationTypes[ct]
+}
+
+// IsTextMimeType checks if the given MIME type represents text-based content
+// suitable for display or processing as text.
+func IsTextMimeType(mimeType string) bool {
+	ct := StripMimeTypeParameters(strings.ToLower(mimeType))
+
+	if strings.HasPrefix(ct, "text/") {
+		return true
+	}
+
+	return textApplicationTypes[ct]
+}
+
+// defaultMimeType is the fallback MIME type for unrecognized content.
+const defaultMimeType = "application/octet-stream"
+
+// StripMimeTypeParameters removes charset and other parameters from MIME types.
+// For example, "text/plain; charset=utf-8" becomes "text/plain".
+func StripMimeTypeParameters(mimeType string) string {
+	if idx := strings.Index(mimeType, ";"); idx != -1 {
+		return strings.TrimSpace(mimeType[:idx])
+	}
+	return mimeType
+}

--- a/utils/mimetype.go
+++ b/utils/mimetype.go
@@ -67,13 +67,14 @@ var binaryApplicationTypes = map[string]bool{
 	"application/vnd.openxmlformats-officedocument.presentationml.presentation": true,
 
 	// Archives
-	"application/zip":     true,
-	"application/gzip":    true,
-	"application/x-tar":   true,
-	"application/x-rar":   true,
-	"application/x-7z":    true,
-	"application/x-bzip":  true,
-	"application/x-bzip2": true,
+	"application/zip":              true,
+	"application/gzip":             true,
+	"application/x-tar":            true,
+	"application/x-rar-compressed": true,
+	"application/vnd.rar":          true,
+	"application/x-7z-compressed":  true,
+	"application/x-bzip":           true,
+	"application/x-bzip2":          true,
 
 	// Generic binary
 	defaultMimeType:        true,
@@ -200,6 +201,13 @@ func IsBinaryMimeType(contentType string) bool {
 	return binaryApplicationTypes[ct]
 }
 
+// textImageTypes are image/* MIME types that are actually text-based.
+//
+//nolint:gochecknoglobals // Package-level lookup table for efficiency
+var textImageTypes = map[string]bool{
+	"image/svg+xml": true,
+}
+
 // IsTextMimeType checks if the given MIME type represents text-based content
 // suitable for display or processing as text.
 func IsTextMimeType(mimeType string) bool {
@@ -209,7 +217,7 @@ func IsTextMimeType(mimeType string) bool {
 		return true
 	}
 
-	return textApplicationTypes[ct]
+	return textApplicationTypes[ct] || textImageTypes[ct]
 }
 
 // defaultMimeType is the fallback MIME type for unrecognized content.

--- a/utils/mimetype.go
+++ b/utils/mimetype.go
@@ -99,6 +99,8 @@ var textApplicationTypes = map[string]bool{
 	"application/x-sh":       true,
 	"application/x-toml":     true,
 	"application/x-ini":      true,
+	"application/jsonl":      true,
+	"application/x-ndjson":   true,
 }
 
 // DetectMimeType detects MIME type using both content (magic bytes) and filename extension.
@@ -179,8 +181,14 @@ func DetectMimeTypeFromReader(r io.Reader, filename string) (string, error) {
 }
 
 // IsBinaryMimeType checks if the given MIME type represents binary data.
+// SVG (image/svg+xml) is excluded since it is a text-based XML format.
 func IsBinaryMimeType(contentType string) bool {
 	ct := StripMimeTypeParameters(strings.ToLower(contentType))
+
+	// SVG is XML-based text, not binary
+	if ct == "image/svg+xml" {
+		return false
+	}
 
 	if strings.HasPrefix(ct, "image/") ||
 		strings.HasPrefix(ct, "audio/") ||

--- a/utils/mimetype_test.go
+++ b/utils/mimetype_test.go
@@ -1,0 +1,312 @@
+package irminutils_test
+
+import (
+	"bytes"
+	"testing"
+
+	irminutils "github.com/IrminData/irmin-sdk-go/utils"
+)
+
+func TestDetectMimeType(t *testing.T) {
+	tests := []struct {
+		name     string
+		content  []byte
+		filename string
+		expected string
+	}{
+		// Specialized extensions take priority regardless of content
+		{
+			name:     "Parquet extension with no content",
+			content:  nil,
+			filename: "data.parquet",
+			expected: "application/vnd.apache.parquet",
+		},
+		{
+			name:     "Avro extension",
+			content:  nil,
+			filename: "data.avro",
+			expected: "application/vnd.apache.avro",
+		},
+		{
+			name:     "YAML extension",
+			content:  nil,
+			filename: "config.yaml",
+			expected: "application/x-yaml",
+		},
+
+		// Content-based detection
+		{
+			name:     "PNG content with matching extension",
+			content:  []byte{0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A},
+			filename: "image.png",
+			expected: "image/png",
+		},
+		{
+			name:     "PNG content with no extension",
+			content:  []byte{0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A},
+			filename: "file",
+			expected: "image/png",
+		},
+		{
+			name:     "JSON content with extension",
+			content:  []byte(`{"key": "value"}`),
+			filename: "data.json",
+			expected: "application/json",
+		},
+		{
+			name:     "PDF magic bytes",
+			content:  []byte("%PDF-1.4 test content"),
+			filename: "doc.pdf",
+			expected: "application/pdf",
+		},
+
+		// Extension fallback when content is empty
+		{
+			name:     "JSON extension no content",
+			content:  nil,
+			filename: "data.json",
+			expected: "application/json",
+		},
+		{
+			name:     "CSV extension no content",
+			content:  nil,
+			filename: "data.csv",
+			expected: "text/csv",
+		},
+		{
+			name:     "Text extension no content",
+			content:  nil,
+			filename: "readme.txt",
+			expected: "text/plain",
+		},
+
+		// Unknown
+		{
+			name:     "Unknown binary no extension",
+			content:  []byte{0x00, 0x01, 0x02, 0x03},
+			filename: "file",
+			expected: "application/octet-stream",
+		},
+		{
+			name:     "Unknown extension no content",
+			content:  nil,
+			filename: "file.unknown",
+			expected: "application/octet-stream",
+		},
+
+		// Empty everything
+		{
+			name:     "Empty content and filename",
+			content:  nil,
+			filename: "",
+			expected: "application/octet-stream",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := irminutils.DetectMimeType(tt.content, tt.filename)
+			if result != tt.expected {
+				t.Errorf("DetectMimeType(%v, %q) = %q, expected %q",
+					tt.content != nil, tt.filename, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestDetectMimeTypeByExtension(t *testing.T) {
+	// Verify all specialized types return expected values
+	specializedTests := map[string]string{
+		"data.parquet": "application/vnd.apache.parquet",
+		"data.avro":    "application/vnd.apache.avro",
+		"data.orc":     "application/vnd.apache.orc",
+		"data.delta":   "application/x-delta-lake",
+		"data.iceberg": "application/x-iceberg",
+		"data.jsonl":   "application/jsonl",
+		"data.ndjson":  "application/x-ndjson",
+		"data.tsv":     "text/tab-separated-values",
+		"data.tab":     "text/tab-separated-values",
+		"config.yaml":  "application/x-yaml",
+		"config.yml":   "application/x-yaml",
+		"data.xlsb":    "application/vnd.ms-excel.sheet.binary.macroEnabled.12",
+		"data.xlsm":    "application/vnd.ms-excel.sheet.macroEnabled.12",
+		"image.heic":   "image/heic",
+		"image.heif":   "image/heif",
+		"image.avif":   "image/avif",
+		"image.webp":   "image/webp",
+		"audio.opus":   "audio/opus",
+		"audio.flac":   "audio/flac",
+		"font.woff":    "font/woff",
+		"font.woff2":   "font/woff2",
+		"font.otf":     "font/otf",
+		"font.ttf":     "font/ttf",
+		"app.js":       "application/javascript",
+		"data.json":    "application/json",
+		"data.csv":     "text/csv",
+		"readme.txt":   "text/plain",
+		"doc.pdf":      "application/pdf",
+		"image.png":    "image/png",
+		"data.xlsx":    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+		"data.xls":     "application/vnd.ms-excel",
+		"data.xml":     "application/xml",
+		"data.zip":     "application/zip",
+		"file.unknown": "application/octet-stream",
+	}
+
+	for filename, expected := range specializedTests {
+		t.Run(filename, func(t *testing.T) {
+			result := irminutils.DetectMimeTypeByExtension(filename)
+			if result != expected {
+				t.Errorf("DetectMimeTypeByExtension(%q) = %q, expected %q",
+					filename, result, expected)
+			}
+		})
+	}
+}
+
+func TestDetectMimeTypeFromReader(t *testing.T) {
+	// Specialized extension takes priority over reader content
+	t.Run("Parquet extension ignores reader", func(t *testing.T) {
+		r := bytes.NewReader([]byte("not really parquet"))
+		result, err := irminutils.DetectMimeTypeFromReader(r, "data.parquet")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if result != "application/vnd.apache.parquet" {
+			t.Errorf("got %q, expected %q", result, "application/vnd.apache.parquet")
+		}
+	})
+
+	t.Run("PNG reader detection", func(t *testing.T) {
+		pngBytes := []byte{0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A}
+		r := bytes.NewReader(pngBytes)
+		result, err := irminutils.DetectMimeTypeFromReader(r, "file")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if result != "image/png" {
+			t.Errorf("got %q, expected %q", result, "image/png")
+		}
+	})
+}
+
+func TestIsBinaryMimeType(t *testing.T) {
+	tests := []struct {
+		mimeType string
+		expected bool
+	}{
+		// Images
+		{"image/png", true},
+		{"image/jpeg", true},
+		{"image/gif", true},
+		{"image/webp", true},
+		{"image/svg+xml", true},
+		{"image/custom-unknown", true}, // prefix match
+
+		// Audio/Video
+		{"audio/mpeg", true},
+		{"audio/wav", true},
+		{"video/mp4", true},
+		{"video/webm", true},
+
+		// Binary application types
+		{"application/pdf", true},
+		{"application/zip", true},
+		{"application/gzip", true},
+		{"application/octet-stream", true},
+		{"application/x-binary", true},
+		{"application/msword", true},
+		{"application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", true},
+
+		// With parameters
+		{"image/png; charset=utf-8", true},
+
+		// Non-binary
+		{"text/plain", false},
+		{"text/html", false},
+		{"application/json", false},
+		{"application/xml", false},
+		{"application/javascript", false},
+		{"", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.mimeType, func(t *testing.T) {
+			result := irminutils.IsBinaryMimeType(tt.mimeType)
+			if result != tt.expected {
+				t.Errorf("IsBinaryMimeType(%q) = %v, expected %v",
+					tt.mimeType, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestIsTextMimeType(t *testing.T) {
+	tests := []struct {
+		mimeType string
+		expected bool
+	}{
+		// Text types
+		{"text/plain", true},
+		{"text/html", true},
+		{"text/csv", true},
+		{"text/xml", true},
+		{"text/plain; charset=utf-8", true},
+
+		// Application text types
+		{"application/json", true},
+		{"application/ld+json", true},
+		{"application/xml", true},
+		{"application/xhtml+xml", true},
+		{"application/x-yaml", true},
+		{"application/yaml", true},
+		{"application/csv", true},
+		{"application/sql", true},
+		{"application/graphql", true},
+		{"application/javascript", true},
+		{"application/ecmascript", true},
+		{"application/x-latex", true},
+		{"application/x-sh", true},
+		{"application/x-toml", true},
+		{"application/x-ini", true},
+
+		// Non-text
+		{"image/png", false},
+		{"application/pdf", false},
+		{"application/octet-stream", false},
+		{"application/zip", false},
+		{"", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.mimeType, func(t *testing.T) {
+			result := irminutils.IsTextMimeType(tt.mimeType)
+			if result != tt.expected {
+				t.Errorf("IsTextMimeType(%q) = %v, expected %v",
+					tt.mimeType, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestStripMimeTypeParameters(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"text/plain; charset=utf-8", "text/plain"},
+		{"application/json", "application/json"},
+		{"text/html; charset=iso-8859-1; boundary=something", "text/html"},
+		{"", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			result := irminutils.StripMimeTypeParameters(tt.input)
+			if result != tt.expected {
+				t.Errorf("StripMimeTypeParameters(%q) = %q, expected %q",
+					tt.input, result, tt.expected)
+			}
+		})
+	}
+}

--- a/utils/mimetype_test.go
+++ b/utils/mimetype_test.go
@@ -200,7 +200,7 @@ func TestIsBinaryMimeType(t *testing.T) {
 		{"image/jpeg", true},
 		{"image/gif", true},
 		{"image/webp", true},
-		{"image/svg+xml", true},
+		{"image/svg+xml", false},       // SVG is text-based XML
 		{"image/custom-unknown", true}, // prefix match
 
 		// Audio/Video
@@ -275,6 +275,8 @@ func TestIsTextMimeType(t *testing.T) {
 		{"application/x-sh", true},
 		{"application/x-toml", true},
 		{"application/x-ini", true},
+		{"application/jsonl", true},
+		{"application/x-ndjson", true},
 
 		// Non-text
 		{"image/png", false},

--- a/utils/mimetype_test.go
+++ b/utils/mimetype_test.go
@@ -219,6 +219,9 @@ func TestIsBinaryMimeType(t *testing.T) {
 		{"application/pdf", true},
 		{"application/zip", true},
 		{"application/gzip", true},
+		{"application/x-rar-compressed", true},
+		{"application/vnd.rar", true},
+		{"application/x-7z-compressed", true},
 		{"application/octet-stream", true},
 		{"application/x-binary", true},
 		{"application/msword", true},
@@ -277,6 +280,9 @@ func TestIsTextMimeType(t *testing.T) {
 		{"application/x-ini", true},
 		{"application/jsonl", true},
 		{"application/x-ndjson", true},
+
+		// Text-based image types
+		{"image/svg+xml", true},
 
 		// Non-text
 		{"image/png", false},

--- a/utils/mimetype_test.go
+++ b/utils/mimetype_test.go
@@ -209,6 +209,12 @@ func TestIsBinaryMimeType(t *testing.T) {
 		{"video/mp4", true},
 		{"video/webm", true},
 
+		// Fonts
+		{"font/woff", true},
+		{"font/woff2", true},
+		{"font/otf", true},
+		{"font/ttf", true},
+
 		// Binary application types
 		{"application/pdf", true},
 		{"application/zip", true},

--- a/utils/parseObjectDetailsFromPath.go
+++ b/utils/parseObjectDetailsFromPath.go
@@ -81,7 +81,7 @@ func ParseObjectDetailsFromPath(inputPath string) ObjectDetails {
 		cleanPath += "/" // Add a trailing slash since groups are bucket object prefixes.
 	} else {
 		// Use hybrid MIME type detection for files
-		contentType = GetContentTypeHybrid(ext)
+		contentType = DetectMimeTypeByExtension("file" + ext)
 
 		// Determine object type based on content type and extension
 		if IsStructuredDataFormat(ext, contentType) {
@@ -99,78 +99,6 @@ func ParseObjectDetailsFromPath(inputPath string) ObjectDetails {
 		Type:        objectType,
 		ContentType: contentType,
 	}
-}
-
-// GetContentTypeHybrid uses a hybrid approach for MIME type detection.
-// It first checks for specialized data analytics formats that aren't typically
-// registered in system MIME databases, then falls back to the system's built-in
-// MIME type detection for standard formats.
-//
-// To maintain backward compatibility with existing tests, this function:
-// - Uses specialized mappings for data analytics formats
-// - Falls back to system MIME types but strips charset parameters
-// - Maintains specific legacy MIME types where expected by existing code
-func GetContentTypeHybrid(ext string) string {
-	// Specialized data analytics and custom formats
-	specializedTypes := map[string]string{
-		// Advanced analytics formats
-		".parquet": "application/vnd.apache.parquet", // Apache Parquet
-		".avro":    "application/vnd.apache.avro",    // Apache Avro
-		".orc":     "application/vnd.apache.orc",     // Apache ORC
-		".delta":   "application/x-delta-lake",       // Delta Lake
-		".iceberg": "application/x-iceberg",          // Apache Iceberg
-
-		// Specialized text formats for data processing
-		".jsonl":  "application/jsonl",         // JSON Lines / Newline-delimited JSON
-		".ndjson": "application/x-ndjson",      // Newline-delimited JSON (alternative)
-		".tsv":    "text/tab-separated-values", // Tab-separated values
-		".tab":    "text/tab-separated-values", // Tab-separated values (alternative)
-		".yaml":   "application/x-yaml",        // YAML (keep consistent for data processing)
-		".yml":    "application/x-yaml",        // YAML alternative extension
-
-		// Excel binary formats (might not be in all systems)
-		".xlsb": "application/vnd.ms-excel.sheet.binary.macroEnabled.12", // Excel binary
-		".xlsm": "application/vnd.ms-excel.sheet.macroEnabled.12",        // Excel with macros
-
-		// Modern image formats that may not be universally recognized
-		".heic": "image/heic", // Apple HEIC format
-		".heif": "image/heif", // Apple HEIF format
-		".avif": "image/avif", // AV1 Image File Format (fallback if not detected)
-		".webp": "image/webp", // WebP (fallback if not detected)
-
-		// Modern audio formats that may not be universally recognized
-		".opus": "audio/opus", // Opus audio codec
-		".flac": "audio/flac", // FLAC lossless audio
-
-		// Font formats that may not be universally recognized
-		".woff":  "font/woff",  // Web Open Font Format
-		".woff2": "font/woff2", // Web Open Font Format 2.0
-		".otf":   "font/otf",   // OpenType Font
-		".ttf":   "font/ttf",   // TrueType Font
-
-		// Legacy overrides for backward compatibility
-		".js": "application/javascript", // Keep legacy JavaScript MIME type for compatibility
-	}
-
-	// Check if it's a specialized format first
-	if mimeType, exists := specializedTypes[ext]; exists {
-		return mimeType
-	}
-
-	// Fall back to system-registered MIME types for standard formats
-	systemMimeType := AutoDetectMimeType("file" + ext)
-
-	// Strip charset and other parameters to maintain backward compatibility
-	return StripMimeTypeParameters(systemMimeType)
-}
-
-// StripMimeTypeParameters removes charset and other parameters from MIME types
-// to maintain backward compatibility with existing test expectations.
-func StripMimeTypeParameters(mimeType string) string {
-	if idx := strings.Index(mimeType, ";"); idx != -1 {
-		return strings.TrimSpace(mimeType[:idx])
-	}
-	return mimeType
 }
 
 // IsStructuredDataFormat determines if a file extension and MIME type represent

--- a/utils/parseObjectDetailsFromPath_test.go
+++ b/utils/parseObjectDetailsFromPath_test.go
@@ -358,7 +358,7 @@ func TestProblematicMimeTypes(t *testing.T) {
 	t.Log("Current MIME type detection results:")
 	for _, tt := range problematicFiles {
 		t.Run(tt.filename, func(t *testing.T) {
-			autoDetected := irminutils.AutoDetectMimeType(tt.filename)
+			autoDetected := irminutils.DetectMimeTypeByExtension(tt.filename)
 			objectDetails := irminutils.ParseObjectDetailsFromPath(tt.filename)
 
 			t.Logf("File: %-12s | AutoDetect: %-30s | ParseObject: %s",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Centralizes MIME detection and updates callers, which can change `ContentType` values and structured/binary classification across the SDK. Behavior is covered by new unit tests, but downstream integrations may rely on previous MIME strings.
> 
> **Overview**
> **Unifies MIME type detection across the SDK** by adding `utils/mimetype.go` with specialized extension mappings, optional content/reader sniffing via `github.com/gabriel-vasile/mimetype`, and helpers `IsBinaryMimeType`/`IsTextMimeType`/`StripMimeTypeParameters`.
> 
> Updates existing call sites to use the new API (`File.MimeType()`, `ParseObjectDetailsFromPath`, and DuckDB `GetContentTypeFromExtension`), and removes the older `AutoDetectMimeType`/`GetContentTypeHybrid` implementations. Adds comprehensive tests for the new detection behavior and regenerates the docs to reflect the new exported functions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7caabf507c117937092633f85d75538a8a269e6a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->