### PR TITLE
Add DataPassMode to pipeline stages

### DIFF
--- a/docs/docs.md
+++ b/docs/docs.md
@@ -3909,6 +3909,7 @@ import "github.com/IrminData/irmin-sdk-go/models"
 - [type ConnectorEventType](<#ConnectorEventType>)
 - [type CustomFieldValues](<#CustomFieldValues>)
 - [type CustomToolType](<#CustomToolType>)
+- [type DataPassMode](<#DataPassMode>)
 - [type Diff](<#Diff>)
 - [type DynamicField](<#DynamicField>)
 - [type DynamicFields](<#DynamicFields>)
@@ -4613,6 +4614,26 @@ const (
 )
 ```
 
+<a name="DataPassMode"></a>
+## type DataPassMode
+
+DataPassMode controls how a pipeline stage's output merges with existing pipeline data.
+
+```go
+type DataPassMode string
+```
+
+<a name="DataPassModeMerge"></a>
+
+```go
+const (
+    // DataPassModeMerge adds/overwrites files in the pipeline data (default).
+    DataPassModeMerge DataPassMode = "merge"
+    // DataPassModeReplace clears all previous pipeline data, keeping only this stage's output.
+    DataPassModeReplace DataPassMode = "replace"
+)
+```
+
 <a name="Diff"></a>
 ## type Diff
 
@@ -5200,11 +5221,12 @@ const (
 
 ```go
 type PipelineStage struct {
-    Description   string            `json:"description"    validate:"required,max=200"                                                                                                                                      example:"Process customer data"`
-    Write         bool              `json:"write"                                                                                                                                                                           example:"true"`
-    Read          bool              `json:"read"                                                                                                                                                                            example:"true"`
-    OrderSequence int               `json:"order_sequence"                                                                                                                                                                  example:"1"`
-    Type          PipelineStageType `json:"type"           validate:"required,oneof=action connection repository repository_action trigger_workflow validation transform embeddings patch field_mapping,validpipelinestage" example:"repository"`
+    Description   string            `json:"description"              validate:"required,max=200"                                                                                                                                      example:"Process customer data"`
+    Write         bool              `json:"write"                                                                                                                                                                                     example:"true"`
+    Read          bool              `json:"read"                                                                                                                                                                                      example:"true"`
+    DataPassMode  DataPassMode      `json:"data_pass_mode,omitempty" validate:"omitempty,oneof=merge replace"                                                                                                                         example:"merge"`
+    OrderSequence int               `json:"order_sequence"                                                                                                                                                                            example:"1"`
+    Type          PipelineStageType `json:"type"                     validate:"required,oneof=action connection repository repository_action trigger_workflow validation transform embeddings patch field_mapping,validpipelinestage" example:"repository"`
 
     // Action stage specific
     ExecutableType ActionExecutableType `json:"executable_type,omitempty" validate:"omitempty,oneof=script query,required_if=Type action"          example:"script"`

--- a/docs/html/github_com_IrminData_irmin-sdk-go_models.html
+++ b/docs/html/github_com_IrminData_irmin-sdk-go_models.html
@@ -392,6 +392,16 @@ const (
 	// CustomToolTypeEmbeddingSearch searches a specific embedding file.
 	CustomToolTypeEmbeddingSearch CustomToolType = "embedding_search"
 )
+type DataPassMode string
+    DataPassMode controls how a pipeline stage's output merges with existing
+    pipeline data.
+
+const (
+	// DataPassModeMerge adds/overwrites files in the pipeline data (default).
+	DataPassModeMerge DataPassMode = "merge"
+	// DataPassModeReplace clears all previous pipeline data, keeping only this stage's output.
+	DataPassModeReplace DataPassMode = "replace"
+)
 type Diff struct {
 	// Slug of the repository
 	Repository string `json:"repository"             validate:"required,validslug" example:"customer-analytics"`
@@ -756,11 +766,12 @@ const (
 	PendingWriteStatusRejected PendingWriteStatus = "rejected"
 )
 type PipelineStage struct {
-	Description   string            `json:"description"    validate:"required,max=200"                                                                                                                                      example:"Process customer data"`
-	Write         bool              `json:"write"                                                                                                                                                                           example:"true"`
-	Read          bool              `json:"read"                                                                                                                                                                            example:"true"`
-	OrderSequence int               `json:"order_sequence"                                                                                                                                                                  example:"1"`
-	Type          PipelineStageType `json:"type"           validate:"required,oneof=action connection repository repository_action trigger_workflow validation transform embeddings patch field_mapping,validpipelinestage" example:"repository"`
+	Description   string            `json:"description"              validate:"required,max=200"                                                                                                                                      example:"Process customer data"`
+	Write         bool              `json:"write"                                                                                                                                                                                     example:"true"`
+	Read          bool              `json:"read"                                                                                                                                                                                      example:"true"`
+	DataPassMode  DataPassMode      `json:"data_pass_mode,omitempty" validate:"omitempty,oneof=merge replace"                                                                                                                         example:"merge"`
+	OrderSequence int               `json:"order_sequence"                                                                                                                                                                            example:"1"`
+	Type          PipelineStageType `json:"type"                     validate:"required,oneof=action connection repository repository_action trigger_workflow validation transform embeddings patch field_mapping,validpipelinestage" example:"repository"`
 
 	// Action stage specific
 	ExecutableType ActionExecutableType `json:"executable_type,omitempty" validate:"omitempty,oneof=script query,required_if=Type action"          example:"script"`

--- a/docs/html/index.html
+++ b/docs/html/index.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8"/>
 <title>github.com/IrminData/irmin-sdk-go documentation</title>
 <h1>github.com/IrminData/irmin-sdk-go documentation</h1>
-<p>Generated on 2026-02-28 15:19 UTC</p>
+<p>Generated on 2026-03-03 09:11 UTC</p>
 <ul>
 <li><a href="github_com_IrminData_irmin-sdk-go.html">github.com/IrminData/irmin-sdk-go</a></li>
 <li><a href="github_com_IrminData_irmin-sdk-go_api.html">github.com/IrminData/irmin-sdk-go/api</a></li>

--- a/models/workflow.go
+++ b/models/workflow.go
@@ -88,6 +88,16 @@ const (
 	PatchDirectionToRepository PatchDirection = "to_repository"
 )
 
+// DataPassMode controls how a pipeline stage's output merges with existing pipeline data.
+type DataPassMode string
+
+const (
+	// DataPassModeMerge adds/overwrites files in the pipeline data (default).
+	DataPassModeMerge DataPassMode = "merge"
+	// DataPassModeReplace clears all previous pipeline data, keeping only this stage's output.
+	DataPassModeReplace DataPassMode = "replace"
+)
+
 // SyncMode represents the synchronization mode for import/export workflows.
 type SyncMode string
 
@@ -110,11 +120,12 @@ const (
 )
 
 type PipelineStage struct {
-	Description   string            `json:"description"    validate:"required,max=200"                                                                                                                                      example:"Process customer data"`
-	Write         bool              `json:"write"                                                                                                                                                                           example:"true"`
-	Read          bool              `json:"read"                                                                                                                                                                            example:"true"`
-	OrderSequence int               `json:"order_sequence"                                                                                                                                                                  example:"1"`
-	Type          PipelineStageType `json:"type"           validate:"required,oneof=action connection repository repository_action trigger_workflow validation transform embeddings patch field_mapping,validpipelinestage" example:"repository"`
+	Description   string            `json:"description"              validate:"required,max=200"                                                                                                                                      example:"Process customer data"`
+	Write         bool              `json:"write"                                                                                                                                                                                     example:"true"`
+	Read          bool              `json:"read"                                                                                                                                                                                      example:"true"`
+	DataPassMode  DataPassMode      `json:"data_pass_mode,omitempty" validate:"omitempty,oneof=merge replace"                                                                                                                         example:"merge"`
+	OrderSequence int               `json:"order_sequence"                                                                                                                                                                            example:"1"`
+	Type          PipelineStageType `json:"type"                     validate:"required,oneof=action connection repository repository_action trigger_workflow validation transform embeddings patch field_mapping,validpipelinestage" example:"repository"`
 
 	// Action stage specific
 	ExecutableType ActionExecutableType `json:"executable_type,omitempty" validate:"omitempty,oneof=script query,required_if=Type action"          example:"script"`


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Adds a new optional field to `PipelineStage` plus an enum type; this is largely backward-compatible but could affect clients that validate/serialize pipeline stage JSON strictly.
> 
> **Overview**
> Adds `DataPassMode` (`merge`/`replace`) to control how a pipeline stage’s output combines with existing pipeline data, exposing it as optional `data_pass_mode` on `PipelineStage` with validation.
> 
> Regenerates the markdown and HTML docs to include the new type and the updated `PipelineStage` schema (plus an updated docs generation timestamp).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e58ba7f4acbd0ff0f79a06840b842c127682836b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->