### PR TITLE
Tim/feat/switch pricing to fully usage based

### DIFF
--- a/api/billing.go
+++ b/api/billing.go
@@ -8,14 +8,12 @@ import (
 	irminmodels "github.com/IrminData/irmin-sdk-go/models"
 )
 
-// CheckoutRequest represents the JSON request body for creating a checkout session or changing a plan.
+// CheckoutRequest represents the JSON request body for creating a checkout session (adding a payment method).
 type CheckoutRequest struct {
-	PlanTier        irminmodels.PlanTier        `json:"plan_tier"         validate:"required" example:"pro"`
-	BillingInterval irminmodels.BillingInterval  `json:"billing_interval" validate:"required" example:"monthly"`
-	ReturnURL       string                       `json:"return_url"       validate:"required" example:"https://app.irmin.io/workspace/my-workspace/settings/billing/success"`
+	ReturnURL string `json:"return_url" validate:"required" example:"https://app.irmin.io/workspace/my-workspace/settings/billing/success"`
 }
 
-// CheckoutResponse represents the response body for checkout and change-plan endpoints.
+// CheckoutResponse represents the response body for checkout endpoints.
 type CheckoutResponse struct {
 	CheckoutURL string `json:"checkout_url" example:"https://polar.sh/checkout/abc123"`
 }
@@ -89,25 +87,6 @@ func (c *Client) CreateCheckout(
 	}, &checkout)
 	if err != nil {
 		return nil, nil, fmt.Errorf("create checkout error: %w", err)
-	}
-	return &checkout, apiResp, nil
-}
-
-// ChangePlan changes the billing plan for a workspace.
-func (c *Client) ChangePlan(
-	ctx context.Context,
-	workspaceSlug string,
-	req CheckoutRequest,
-) (*CheckoutResponse, *irminmodels.IrminAPIResponse, error) {
-	var checkout CheckoutResponse
-	apiResp, err := c.FetchAPI(ctx, RequestOptions{
-		Method:      http.MethodPost,
-		Endpoint:    fmt.Sprintf("/v1/workspaces/%s/billing/change-plan", workspaceSlug),
-		ContentType: "application/json",
-		Body:        req,
-	}, &checkout)
-	if err != nil {
-		return nil, nil, fmt.Errorf("change plan error: %w", err)
 	}
 	return &checkout, apiResp, nil
 }

--- a/docs/docs.md
+++ b/docs/docs.md
@@ -181,7 +181,6 @@ import "github.com/IrminData/irmin-sdk-go/api"
   - [func \(c \*Client\) AssociatePresignedUpload\(ctx context.Context, workspace, repository, ref, path string, req AssociatePresignedUploadRequest\) \(\*irminmodels.Object, \*irminmodels.IrminAPIResponse, error\)](<#Client.AssociatePresignedUpload>)
   - [func \(c \*Client\) CallSystemWebhook\(ctx context.Context, webhookType string, headers map\[string\]string, body any\) \(\*irminmodels.IrminAPIResponse, error\)](<#Client.CallSystemWebhook>)
   - [func \(c \*Client\) CancelWorkflowRun\(ctx context.Context, workspace, workflowID, runID string\) \(\*irminmodels.WorkflowRun, \*irminmodels.IrminAPIResponse, error\)](<#Client.CancelWorkflowRun>)
-  - [func \(c \*Client\) ChangePlan\(ctx context.Context, workspaceSlug string, req CheckoutRequest\) \(\*CheckoutResponse, \*irminmodels.IrminAPIResponse, error\)](<#Client.ChangePlan>)
   - [func \(c \*Client\) CheckPermission\(ctx context.Context, workspace string, resource irminmodels.PolicyResource, action irminmodels.PolicyAction, resourceID \*string\) \(bool, error\)](<#Client.CheckPermission>)
   - [func \(c \*Client\) CompareRefs\(ctx context.Context, workspace, repository, baseRef, compareRef string\) \(\*irminmodels.Diff, \*irminmodels.IrminAPIResponse, error\)](<#Client.CompareRefs>)
   - [func \(c \*Client\) CopyObject\(ctx context.Context, workspace, repository, path, ref string, req MoveObjectRequest\) \(\*irminmodels.Object, \*irminmodels.IrminAPIResponse, error\)](<#Client.CopyObject>)
@@ -821,19 +820,18 @@ type AssociatePresignedUploadRequest struct {
 <a name="CheckoutRequest"></a>
 ## type CheckoutRequest
 
-CheckoutRequest represents the JSON request body for creating a checkout session or changing a plan.
+CheckoutRequest represents the JSON request body for creating a checkout session \(adding a payment method\).
 
 ```go
 type CheckoutRequest struct {
-    PlanTier  irminmodels.PlanTier `json:"plan_tier"  validate:"required" example:"pro"`
-    ReturnURL string               `json:"return_url" validate:"required" example:"https://app.irmin.io/workspace/my-workspace/settings/billing/success"`
+    ReturnURL string `json:"return_url" validate:"required" example:"https://app.irmin.io/workspace/my-workspace/settings/billing/success"`
 }
 ```
 
 <a name="CheckoutResponse"></a>
 ## type CheckoutResponse
 
-CheckoutResponse represents the response body for checkout and change\-plan endpoints.
+CheckoutResponse represents the response body for checkout endpoints.
 
 ```go
 type CheckoutResponse struct {
@@ -938,15 +936,6 @@ func (c *Client) CancelWorkflowRun(ctx context.Context, workspace, workflowID, r
 ```
 
 
-
-<a name="Client.ChangePlan"></a>
-### func \(\*Client\) ChangePlan
-
-```go
-func (c *Client) ChangePlan(ctx context.Context, workspaceSlug string, req CheckoutRequest) (*CheckoutResponse, *irminmodels.IrminAPIResponse, error)
-```
-
-ChangePlan changes the billing plan for a workspace.
 
 <a name="Client.CheckPermission"></a>
 ### func \(\*Client\) CheckPermission
@@ -3989,7 +3978,6 @@ import "github.com/IrminData/irmin-sdk-go/models"
 - [type APIToken](<#APIToken>)
 - [type ActionExecutableType](<#ActionExecutableType>)
 - [type ActionInputData](<#ActionInputData>)
-- [type BillingInterval](<#BillingInterval>)
 - [type Branch](<#Branch>)
 - [type BranchGarbageCollectionRules](<#BranchGarbageCollectionRules>)
 - [type ChangeItem](<#ChangeItem>)
@@ -4041,7 +4029,6 @@ import "github.com/IrminData/irmin-sdk-go/models"
 - [type PipelineStage](<#PipelineStage>)
 - [type PipelineStageType](<#PipelineStageType>)
 - [type PlanInfo](<#PlanInfo>)
-- [type PlanTier](<#PlanTier>)
 - [type PointerTarget](<#PointerTarget>)
 - [type Policy](<#Policy>)
 - [type PolicyAction](<#PolicyAction>)
@@ -4382,26 +4369,6 @@ type ActionInputData struct {
     RepositoryRef  string `json:"repository_ref"  validate:"required"  example:"main"`
     RepositoryPath string `json:"repository_path" validate:"omitempty" example:"/data/customers.csv"`
 }
-```
-
-<a name="BillingInterval"></a>
-## type BillingInterval
-
-BillingInterval represents the billing interval.
-
-```go
-type BillingInterval string
-```
-
-<a name="BillingIntervalMonthly"></a>
-
-```go
-const (
-    // BillingIntervalMonthly represents monthly billing.
-    BillingIntervalMonthly BillingInterval = "monthly"
-    // BillingIntervalAnnual represents annual billing.
-    BillingIntervalAnnual BillingInterval = "annual"
-)
 ```
 
 <a name="Branch"></a>
@@ -5462,38 +5429,14 @@ PlanInfo holds information about a workspace's current plan.
 
 ```go
 type PlanInfo struct {
-    Tier                PlanTier           `json:"tier"                  example:"pro"`
-    Status              SubscriptionStatus `json:"status"                example:"active"`
-    BillingInterval     BillingInterval    `json:"billing_interval"      example:"monthly"`
-    PeriodStart         *time.Time         `json:"current_period_start"  example:"2025-01-01T00:00:00Z"`
-    PeriodEnd           *time.Time         `json:"current_period_end"    example:"2025-02-01T00:00:00Z"`
-    CancelledAt         *time.Time         `json:"cancelled_at"          example:"2025-03-15T12:00:00Z"`
-    IncludedUsageCredit float64            `json:"included_usage_credit" example:"20.00"`
+    Status           SubscriptionStatus `json:"status"               example:"active"`
+    HasPaymentMethod bool               `json:"has_payment_method"   example:"true"`
+    PeriodStart      *time.Time         `json:"current_period_start" example:"2025-01-01T00:00:00Z"`
+    PeriodEnd        *time.Time         `json:"current_period_end"   example:"2025-02-01T00:00:00Z"`
+    CancelledAt      *time.Time         `json:"cancelled_at"         example:"2025-03-15T12:00:00Z"`
+    CreditPerMeter   float64            `json:"credit_per_meter"     example:"2.00"`
+    TotalCredit      float64            `json:"total_credit"         example:"12.00"`
 }
-```
-
-<a name="PlanTier"></a>
-## type PlanTier
-
-PlanTier represents the billing plan tier.
-
-```go
-type PlanTier string
-```
-
-<a name="PlanTierHobby"></a>
-
-```go
-const (
-    // PlanTierHobby represents the hobby plan tier.
-    PlanTierHobby PlanTier = "hobby"
-    // PlanTierPro represents the pro plan tier.
-    PlanTierPro PlanTier = "pro"
-    // PlanTierTeam represents the team plan tier.
-    PlanTierTeam PlanTier = "team"
-    // PlanTierEnterprise represents the enterprise plan tier.
-    PlanTierEnterprise PlanTier = "enterprise"
-)
 ```
 
 <a name="PointerTarget"></a>
@@ -6561,6 +6504,8 @@ const (
     UsageDimensionAPIRequests UsageDimension = "api_requests"
     // UsageDimensionDataTransfer represents data transfer usage.
     UsageDimensionDataTransfer UsageDimension = "data_transfer"
+    // UsageDimensionSeats represents seat usage.
+    UsageDimensionSeats UsageDimension = "seats"
 )
 ```
 

--- a/docs/html/github_com_IrminData_irmin-sdk-go_api.html
+++ b/docs/html/github_com_IrminData_irmin-sdk-go_api.html
@@ -247,17 +247,15 @@ type AssociatePresignedUploadRequest struct {
     associating a staged upload.
 
 type CheckoutRequest struct {
-	PlanTier  irminmodels.PlanTier `json:"plan_tier"  validate:"required" example:"pro"`
-	ReturnURL string               `json:"return_url" validate:"required" example:"https://app.irmin.io/workspace/my-workspace/settings/billing/success"`
+	ReturnURL string `json:"return_url" validate:"required" example:"https://app.irmin.io/workspace/my-workspace/settings/billing/success"`
 }
     CheckoutRequest represents the JSON request body for creating a checkout
-    session or changing a plan.
+    session (adding a payment method).
 
 type CheckoutResponse struct {
 	CheckoutURL string `json:"checkout_url" example:"https://polar.sh/checkout/abc123"`
 }
-    CheckoutResponse represents the response body for checkout and change-plan
-    endpoints.
+    CheckoutResponse represents the response body for checkout endpoints.
 
 type Client struct {
 	// BaseURL is your Irmin Core API base: e.g. "https://api.irmin.co/api"
@@ -326,13 +324,6 @@ func (c *Client) CancelWorkflowRun(
 	ctx context.Context,
 	workspace, workflowID, runID string,
 ) (*irminmodels.WorkflowRun, *irminmodels.IrminAPIResponse, error)
-
-func (c *Client) ChangePlan(
-	ctx context.Context,
-	workspaceSlug string,
-	req CheckoutRequest,
-) (*CheckoutResponse, *irminmodels.IrminAPIResponse, error)
-    ChangePlan changes the billing plan for a workspace.
 
 func (c *Client) CheckPermission(
 	ctx context.Context,

--- a/docs/html/github_com_IrminData_irmin-sdk-go_models.html
+++ b/docs/html/github_com_IrminData_irmin-sdk-go_models.html
@@ -186,15 +186,6 @@ type ActionInputData struct {
 	RepositoryPath string `json:"repository_path" validate:"omitempty" example:"/data/customers.csv"`
 }
 
-type BillingInterval string
-    BillingInterval represents the billing interval.
-
-const (
-	// BillingIntervalMonthly represents monthly billing.
-	BillingIntervalMonthly BillingInterval = "monthly"
-	// BillingIntervalAnnual represents annual billing.
-	BillingIntervalAnnual BillingInterval = "annual"
-)
 type Branch struct {
 	// Name of the branch
 	Name string `json:"name"         validate:"required,max=100,validslug" example:"main"`
@@ -873,29 +864,16 @@ const (
 	PipelineStageTypeFieldMapping     PipelineStageType = "field_mapping"
 )
 type PlanInfo struct {
-	Tier                PlanTier           `json:"tier"                  example:"pro"`
-	Status              SubscriptionStatus `json:"status"                example:"active"`
-	BillingInterval     BillingInterval    `json:"billing_interval"      example:"monthly"`
-	PeriodStart         *time.Time         `json:"current_period_start"  example:"2025-01-01T00:00:00Z"`
-	PeriodEnd           *time.Time         `json:"current_period_end"    example:"2025-02-01T00:00:00Z"`
-	CancelledAt         *time.Time         `json:"cancelled_at"          example:"2025-03-15T12:00:00Z"`
-	IncludedUsageCredit float64            `json:"included_usage_credit" example:"20.00"`
+	Status           SubscriptionStatus `json:"status"               example:"active"`
+	HasPaymentMethod bool               `json:"has_payment_method"   example:"true"`
+	PeriodStart      *time.Time         `json:"current_period_start" example:"2025-01-01T00:00:00Z"`
+	PeriodEnd        *time.Time         `json:"current_period_end"   example:"2025-02-01T00:00:00Z"`
+	CancelledAt      *time.Time         `json:"cancelled_at"         example:"2025-03-15T12:00:00Z"`
+	CreditPerMeter   float64            `json:"credit_per_meter"     example:"2.00"`
+	TotalCredit      float64            `json:"total_credit"         example:"12.00"`
 }
     PlanInfo holds information about a workspace's current plan.
 
-type PlanTier string
-    PlanTier represents the billing plan tier.
-
-const (
-	// PlanTierHobby represents the hobby plan tier.
-	PlanTierHobby PlanTier = "hobby"
-	// PlanTierPro represents the pro plan tier.
-	PlanTierPro PlanTier = "pro"
-	// PlanTierTeam represents the team plan tier.
-	PlanTierTeam PlanTier = "team"
-	// PlanTierEnterprise represents the enterprise plan tier.
-	PlanTierEnterprise PlanTier = "enterprise"
-)
 type PointerTarget struct {
 	// Workspace is the target workspace slug. Empty string means same workspace.
 	Workspace string `json:"target_workspace,omitempty" validate:"omitempty,max=100" example:""`
@@ -1548,6 +1526,8 @@ const (
 	UsageDimensionAPIRequests UsageDimension = "api_requests"
 	// UsageDimensionDataTransfer represents data transfer usage.
 	UsageDimensionDataTransfer UsageDimension = "data_transfer"
+	// UsageDimensionSeats represents seat usage.
+	UsageDimensionSeats UsageDimension = "seats"
 )
 type UsageDimensionInfo struct {
 	Dimension    UsageDimension `json:"dimension"     example:"api_requests"`

--- a/docs/html/index.html
+++ b/docs/html/index.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8"/>
 <title>github.com/IrminData/irmin-sdk-go documentation</title>
 <h1>github.com/IrminData/irmin-sdk-go documentation</h1>
-<p>Generated on 2026-03-09 11:55 UTC</p>
+<p>Generated on 2026-03-10 06:24 UTC</p>
 <ul>
 <li><a href="github_com_IrminData_irmin-sdk-go.html">github.com/IrminData/irmin-sdk-go</a></li>
 <li><a href="github_com_IrminData_irmin-sdk-go_api.html">github.com/IrminData/irmin-sdk-go/api</a></li>

--- a/models/billing.go
+++ b/models/billing.go
@@ -2,30 +2,6 @@ package irminmodels
 
 import "time"
 
-// PlanTier represents the billing plan tier.
-type PlanTier string
-
-const (
-	// PlanTierHobby represents the hobby plan tier.
-	PlanTierHobby PlanTier = "hobby"
-	// PlanTierPro represents the pro plan tier.
-	PlanTierPro PlanTier = "pro"
-	// PlanTierTeam represents the team plan tier.
-	PlanTierTeam PlanTier = "team"
-	// PlanTierEnterprise represents the enterprise plan tier.
-	PlanTierEnterprise PlanTier = "enterprise"
-)
-
-// BillingInterval represents the billing interval.
-type BillingInterval string
-
-const (
-	// BillingIntervalMonthly represents monthly billing.
-	BillingIntervalMonthly BillingInterval = "monthly"
-	// BillingIntervalAnnual represents annual billing.
-	BillingIntervalAnnual BillingInterval = "annual"
-)
-
 // SubscriptionStatus represents the status of a subscription.
 type SubscriptionStatus string
 
@@ -56,17 +32,19 @@ const (
 	UsageDimensionAPIRequests UsageDimension = "api_requests"
 	// UsageDimensionDataTransfer represents data transfer usage.
 	UsageDimensionDataTransfer UsageDimension = "data_transfer"
+	// UsageDimensionSeats represents seat usage.
+	UsageDimensionSeats UsageDimension = "seats"
 )
 
 // PlanInfo holds information about a workspace's current plan.
 type PlanInfo struct {
-	Tier                PlanTier           `json:"tier"                  example:"pro"`
-	Status              SubscriptionStatus `json:"status"                example:"active"`
-	BillingInterval     BillingInterval    `json:"billing_interval"      example:"monthly"`
-	PeriodStart         *time.Time         `json:"current_period_start"  example:"2025-01-01T00:00:00Z"`
-	PeriodEnd           *time.Time         `json:"current_period_end"    example:"2025-02-01T00:00:00Z"`
-	CancelledAt         *time.Time         `json:"cancelled_at"          example:"2025-03-15T12:00:00Z"`
-	IncludedUsageCredit float64            `json:"included_usage_credit" example:"20.00"`
+	Status           SubscriptionStatus `json:"status"                example:"active"`
+	HasPaymentMethod bool               `json:"has_payment_method"    example:"true"`
+	PeriodStart      *time.Time         `json:"current_period_start"  example:"2025-01-01T00:00:00Z"`
+	PeriodEnd        *time.Time         `json:"current_period_end"    example:"2025-02-01T00:00:00Z"`
+	CancelledAt      *time.Time         `json:"cancelled_at"          example:"2025-03-15T12:00:00Z"`
+	CreditPerMeter   float64            `json:"credit_per_meter"      example:"2.00"`
+	TotalCredit      float64            `json:"total_credit"          example:"12.00"`
 }
 
 // UsageDimensionInfo holds usage info for a single dimension in the current period.

--- a/models/billing.go
+++ b/models/billing.go
@@ -38,13 +38,13 @@ const (
 
 // PlanInfo holds information about a workspace's current plan.
 type PlanInfo struct {
-	Status           SubscriptionStatus `json:"status"                example:"active"`
-	HasPaymentMethod bool               `json:"has_payment_method"    example:"true"`
-	PeriodStart      *time.Time         `json:"current_period_start"  example:"2025-01-01T00:00:00Z"`
-	PeriodEnd        *time.Time         `json:"current_period_end"    example:"2025-02-01T00:00:00Z"`
-	CancelledAt      *time.Time         `json:"cancelled_at"          example:"2025-03-15T12:00:00Z"`
-	CreditPerMeter   float64            `json:"credit_per_meter"      example:"2.00"`
-	TotalCredit      float64            `json:"total_credit"          example:"12.00"`
+	Status           SubscriptionStatus `json:"status"               example:"active"`
+	HasPaymentMethod bool               `json:"has_payment_method"   example:"true"`
+	PeriodStart      *time.Time         `json:"current_period_start" example:"2025-01-01T00:00:00Z"`
+	PeriodEnd        *time.Time         `json:"current_period_end"   example:"2025-02-01T00:00:00Z"`
+	CancelledAt      *time.Time         `json:"cancelled_at"         example:"2025-03-15T12:00:00Z"`
+	CreditPerMeter   float64            `json:"credit_per_meter"     example:"2.00"`
+	TotalCredit      float64            `json:"total_credit"         example:"12.00"`
 }
 
 // UsageDimensionInfo holds usage info for a single dimension in the current period.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Medium risk due to breaking SDK surface changes: removed plan tier/interval types and the `ChangePlan` endpoint, and reshaped `PlanInfo` fields, which will require client updates and could cause runtime JSON mismatches if backend isn’t in lockstep.
> 
> **Overview**
> Updates billing to a *fully usage-based* shape by removing plan tier/interval concepts from the SDK.
> 
> `CheckoutRequest` is simplified to only collect `return_url` (checkout now framed as adding a payment method), the `ChangePlan` client method/endpoint is removed, and `PlanInfo` is reworked to expose payment-method presence and credit metrics (`credit_per_meter`, `total_credit`) instead of tier/interval and included credit. Adds `seats` as a new `UsageDimension`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b3131797f6fe2adf4d42fa6797c4bb0c35143f1f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->