### PR TITLE
repository download signed url

### DIFF
--- a/api/repository-objects.go
+++ b/api/repository-objects.go
@@ -72,8 +72,8 @@ type CreateSignedURLRequest struct {
 
 // CreateSignedZipURLRequest represents the JSON request body for creating a signed repository zip download URL.
 type CreateSignedZipURLRequest struct {
-	Ref            string `json:"ref,omitempty"                                         example:"main"`
-	ExpiresInHours *int   `json:"expires_in_hours,omitempty" validate:"omitempty,min=0" example:"24"`
+	Ref            string `json:"ref,omitempty"              example:"main"`
+	ExpiresInHours *int   `json:"expires_in_hours,omitempty" example:"24"   validate:"omitempty,min=0"`
 }
 
 // SignedURLResponse represents the response from creating a signed download URL.

--- a/api/repository-objects.go
+++ b/api/repository-objects.go
@@ -70,6 +70,12 @@ type CreateSignedURLRequest struct {
 	ExpiresInHours *int   `json:"expires_in_hours,omitempty" validate:"omitempty,min=0" example:"24"`
 }
 
+// CreateSignedZipURLRequest represents the JSON request body for creating a signed repository zip download URL.
+type CreateSignedZipURLRequest struct {
+	Ref            string `json:"ref,omitempty"                                         example:"main"`
+	ExpiresInHours *int   `json:"expires_in_hours,omitempty" validate:"omitempty,min=0" example:"24"`
+}
+
 // SignedURLResponse represents the response from creating a signed download URL.
 type SignedURLResponse struct {
 	URL       string `json:"url"        example:"https://api.irmin.co/api/v1/signed/download?token=..."`
@@ -417,6 +423,31 @@ func (c *Client) CreateSignedObjectURL(
 	}, &response)
 	if err != nil {
 		return nil, nil, fmt.Errorf("create signed object URL error: %w", err)
+	}
+	return &response, apiResp, nil
+}
+
+// CreateSignedRepositoryZipURL creates a time-limited signed download URL for an entire repository as a ZIP.
+// The URL can be shared with external users who do not have Irmin accounts.
+// Permissions are checked at creation time, not at download time.
+func (c *Client) CreateSignedRepositoryZipURL(
+	ctx context.Context,
+	workspace, repoSlug string,
+	req CreateSignedZipURLRequest,
+) (*SignedURLResponse, *irminmodels.IrminAPIResponse, error) {
+	var response SignedURLResponse
+	apiResp, err := c.FetchAPI(ctx, RequestOptions{
+		Method: http.MethodPost,
+		Endpoint: fmt.Sprintf(
+			"/v1/workspaces/%s/repositories/%s/signed-zip-url",
+			workspace,
+			repoSlug,
+		),
+		ContentType: "application/json",
+		Body:        req,
+	}, &response)
+	if err != nil {
+		return nil, nil, fmt.Errorf("create signed repository zip URL error: %w", err)
 	}
 	return &response, apiResp, nil
 }

--- a/docs/docs.md
+++ b/docs/docs.md
@@ -2885,8 +2885,8 @@ CreateSignedZipURLRequest represents the JSON request body for creating a signed
 
 ```go
 type CreateSignedZipURLRequest struct {
-    Ref            string `json:"ref,omitempty"                                         example:"main"`
-    ExpiresInHours *int   `json:"expires_in_hours,omitempty" validate:"omitempty,min=0" example:"24"`
+    Ref            string `json:"ref,omitempty"              example:"main"`
+    ExpiresInHours *int   `json:"expires_in_hours,omitempty" example:"24"   validate:"omitempty,min=0"`
 }
 ```
 

--- a/docs/docs.md
+++ b/docs/docs.md
@@ -195,6 +195,7 @@ import "github.com/IrminData/irmin-sdk-go/api"
   - [func \(c \*Client\) CreatePortalSession\(ctx context.Context, workspaceSlug string\) \(\*PortalResponse, \*irminmodels.IrminAPIResponse, error\)](<#Client.CreatePortalSession>)
   - [func \(c \*Client\) CreateRepository\(ctx context.Context, workspace string, req CreateRepositoryRequest\) \(\*irminmodels.Repository, \*irminmodels.IrminAPIResponse, error\)](<#Client.CreateRepository>)
   - [func \(c \*Client\) CreateSignedObjectURL\(ctx context.Context, workspace, repoSlug string, req CreateSignedURLRequest\) \(\*SignedURLResponse, \*irminmodels.IrminAPIResponse, error\)](<#Client.CreateSignedObjectURL>)
+  - [func \(c \*Client\) CreateSignedRepositoryZipURL\(ctx context.Context, workspace, repoSlug string, req CreateSignedZipURLRequest\) \(\*SignedURLResponse, \*irminmodels.IrminAPIResponse, error\)](<#Client.CreateSignedRepositoryZipURL>)
   - [func \(c \*Client\) CreateStoredQuery\(ctx context.Context, workspace string, req CreateQueryRequest\) \(\*irminmodels.StoredQuery, \*irminmodels.IrminAPIResponse, error\)](<#Client.CreateStoredQuery>)
   - [func \(c \*Client\) CreateStoredScript\(ctx context.Context, workspace string, req CreateScriptRequest\) \(\*irminmodels.StoredScript, \*irminmodels.IrminAPIResponse, error\)](<#Client.CreateStoredScript>)
   - [func \(c \*Client\) CreateTag\(ctx context.Context, workspace, repository string, req CreateRepositoryTagRequest\) \(\*irminmodels.GitTag, \*irminmodels.IrminAPIResponse, error\)](<#Client.CreateTag>)
@@ -380,6 +381,7 @@ import "github.com/IrminData/irmin-sdk-go/api"
 - [type CreateRepositoryTagRequest](<#CreateRepositoryTagRequest>)
 - [type CreateScriptRequest](<#CreateScriptRequest>)
 - [type CreateSignedURLRequest](<#CreateSignedURLRequest>)
+- [type CreateSignedZipURLRequest](<#CreateSignedZipURLRequest>)
 - [type CreateTagRequest](<#CreateTagRequest>)
 - [type CreateWorkspaceRequest](<#CreateWorkspaceRequest>)
 - [type CustomToolInfo](<#CustomToolInfo>)
@@ -1065,6 +1067,15 @@ func (c *Client) CreateSignedObjectURL(ctx context.Context, workspace, repoSlug 
 ```
 
 CreateSignedObjectURL creates a time\-limited signed download URL for a repository object. The URL can be shared with external users who do not have Irmin accounts. Permissions are checked at creation time, not at download time.
+
+<a name="Client.CreateSignedRepositoryZipURL"></a>
+### func \(\*Client\) CreateSignedRepositoryZipURL
+
+```go
+func (c *Client) CreateSignedRepositoryZipURL(ctx context.Context, workspace, repoSlug string, req CreateSignedZipURLRequest) (*SignedURLResponse, *irminmodels.IrminAPIResponse, error)
+```
+
+CreateSignedRepositoryZipURL creates a time\-limited signed download URL for an entire repository as a ZIP. The URL can be shared with external users who do not have Irmin accounts. Permissions are checked at creation time, not at download time.
 
 <a name="Client.CreateStoredQuery"></a>
 ### func \(\*Client\) CreateStoredQuery
@@ -2862,6 +2873,18 @@ CreateSignedURLRequest represents the JSON request body for creating a signed do
 ```go
 type CreateSignedURLRequest struct {
     Path           string `json:"path"                       validate:"required"        example:"data/file.csv"`
+    Ref            string `json:"ref,omitempty"                                         example:"main"`
+    ExpiresInHours *int   `json:"expires_in_hours,omitempty" validate:"omitempty,min=0" example:"24"`
+}
+```
+
+<a name="CreateSignedZipURLRequest"></a>
+## type CreateSignedZipURLRequest
+
+CreateSignedZipURLRequest represents the JSON request body for creating a signed repository zip download URL.
+
+```go
+type CreateSignedZipURLRequest struct {
     Ref            string `json:"ref,omitempty"                                         example:"main"`
     ExpiresInHours *int   `json:"expires_in_hours,omitempty" validate:"omitempty,min=0" example:"24"`
 }

--- a/docs/html/github_com_IrminData_irmin-sdk-go_api.html
+++ b/docs/html/github_com_IrminData_irmin-sdk-go_api.html
@@ -1623,8 +1623,8 @@ type CreateSignedURLRequest struct {
     signed download URL.
 
 type CreateSignedZipURLRequest struct {
-	Ref            string `json:"ref,omitempty"                                         example:"main"`
-	ExpiresInHours *int   `json:"expires_in_hours,omitempty" validate:"omitempty,min=0" example:"24"`
+	Ref            string `json:"ref,omitempty"              example:"main"`
+	ExpiresInHours *int   `json:"expires_in_hours,omitempty" example:"24"   validate:"omitempty,min=0"`
 }
     CreateSignedZipURLRequest represents the JSON request body for creating a
     signed repository zip download URL.

--- a/docs/html/github_com_IrminData_irmin-sdk-go_api.html
+++ b/docs/html/github_com_IrminData_irmin-sdk-go_api.html
@@ -426,6 +426,16 @@ func (c *Client) CreateSignedObjectURL(
     Irmin accounts. Permissions are checked at creation time, not at download
     time.
 
+func (c *Client) CreateSignedRepositoryZipURL(
+	ctx context.Context,
+	workspace, repoSlug string,
+	req CreateSignedZipURLRequest,
+) (*SignedURLResponse, *irminmodels.IrminAPIResponse, error)
+    CreateSignedRepositoryZipURL creates a time-limited signed download URL for
+    an entire repository as a ZIP. The URL can be shared with external users
+    who do not have Irmin accounts. Permissions are checked at creation time,
+    not at download time.
+
 func (c *Client) CreateStoredQuery(
 	ctx context.Context,
 	workspace string,
@@ -1611,6 +1621,13 @@ type CreateSignedURLRequest struct {
 }
     CreateSignedURLRequest represents the JSON request body for creating a
     signed download URL.
+
+type CreateSignedZipURLRequest struct {
+	Ref            string `json:"ref,omitempty"                                         example:"main"`
+	ExpiresInHours *int   `json:"expires_in_hours,omitempty" validate:"omitempty,min=0" example:"24"`
+}
+    CreateSignedZipURLRequest represents the JSON request body for creating a
+    signed repository zip download URL.
 
 type CreateTagRequest struct {
 	Name        string `json:"name"                  validate:"required,validslug" example:"v1.0.0"`

--- a/docs/html/index.html
+++ b/docs/html/index.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8"/>
 <title>github.com/IrminData/irmin-sdk-go documentation</title>
 <h1>github.com/IrminData/irmin-sdk-go documentation</h1>
-<p>Generated on 2026-03-14 19:15 UTC</p>
+<p>Generated on 2026-03-15 05:25 UTC</p>
 <ul>
 <li><a href="github_com_IrminData_irmin-sdk-go.html">github.com/IrminData/irmin-sdk-go</a></li>
 <li><a href="github_com_IrminData_irmin-sdk-go_api.html">github.com/IrminData/irmin-sdk-go/api</a></li>

--- a/docs/html/index.html
+++ b/docs/html/index.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8"/>
 <title>github.com/IrminData/irmin-sdk-go documentation</title>
 <h1>github.com/IrminData/irmin-sdk-go documentation</h1>
-<p>Generated on 2026-03-15 05:25 UTC</p>
+<p>Generated on 2026-03-15 05:28 UTC</p>
 <ul>
 <li><a href="github_com_IrminData_irmin-sdk-go.html">github.com/IrminData/irmin-sdk-go</a></li>
 <li><a href="github_com_IrminData_irmin-sdk-go_api.html">github.com/IrminData/irmin-sdk-go/api</a></li>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds a new client method for generating shareable signed repository ZIP download URLs; risk is mainly around correct endpoint/parameter usage for access-controlled downloads.
> 
> **Overview**
> Adds support in the Go SDK to request **time-limited signed download URLs for an entire repository ZIP**.
> 
> Introduces `CreateSignedZipURLRequest` and a new `Client.CreateSignedRepositoryZipURL` call that POSTs to `.../repositories/{repo}/signed-zip-url`, returning the existing `SignedURLResponse`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 313360f624dbdc90d6219f1562f89d95fcb64871. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->