### PR TITLE
feat(observability): add shared progress-event vocabulary

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ A comprehensive Go SDK for the Irmin platform, providing type-safe access to the
 - **🆔 SQID Management**: Unique identifier generation and validation
 - **🔗 Connector Client**: Manage data source connections and operations
 - **📊 DuckDB Client**: In-memory data processing with SQL analytics for CSV, JSON, Parquet and more
+- **📡 Observability**: Shared progress-event vocabulary for long-running operations (see [observability/](#observability))
 - **🛠️ Utilities**: Helper functions for common tasks (JSON schema generation, file handling, etc.)
 
 ## Installation
@@ -337,6 +338,39 @@ results, err := client.QueryToMap(`
 ```
 
 📚 **[Full DuckDB Documentation →](./duckdb/README.md)**
+
+## Observability
+
+Shared progress-event vocabulary for long-running operations. Producers
+fire `ProgressEvent`s into a `ProgressHandler`; the handler routes them
+to the right sink (operation log row, workflow log, NDJSON stream).
+The taxonomy is consistent across services so a `"page"` event means
+the same thing whether it comes from a connector, a Core workflow, or
+the AI service.
+
+```go
+import "github.com/IrminData/irmin-sdk-go/observability"
+
+// Define a handler that emits to your sink:
+handler := observability.ProgressHandler(func(ev observability.ProgressEvent) {
+    // ...persist, log, or stream the event...
+})
+
+// Producers fire events from inside long loops:
+handler(observability.ProgressEvent{
+    Kind:         observability.ProgressKindPage,
+    ResourcePath: "/v1/customers",
+    Page:         5,
+    RecordsSoFar: 500,
+    Cursor:       "cus_abc",
+})
+```
+
+The kinds (`page`, `rate_limit`, `batch`, `query`, `file`, `heartbeat`)
+are stable wire-format strings; an irmin-ai TypeScript consumer will
+see the same values. Sink-aware helpers (DB persistence, throttling,
+heartbeat tickers) live in the consuming service — irmin-connectors
+ships its own under `connectors/common`.
 
 ## Utilities
 

--- a/docs/docs.md
+++ b/docs/docs.md
@@ -6953,6 +6953,120 @@ type WorkspaceSummary struct {
 }
 ```
 
+# observability
+
+```go
+import "github.com/IrminData/irmin-sdk-go/observability"
+```
+
+Package observability defines the shared progress\-event vocabulary used across Irmin services and connectors. The types here are pure data — no database, no logger, no transport. Sink\-aware helpers \(e.g., emission to an OperationLog table or a stream response\) live in the consuming service since the right sink differs per service:
+
+- irmin\-connectors emits to OperationLog rows via LogOperationProgress \+ LogOperationEvent.
+- irmin Core emits to WorkflowRun.Logs via WorkflowLogBuilder.
+- irmin\-ai emits as NDJSON stream events to the chat client.
+
+Centralising the vocabulary \(kinds, event shape, handler signature\) here keeps the operator\-facing semantics consistent across those surfaces — a "page" event means the same thing in every service — and lets external connector authors building against this SDK reach the types directly without depending on irmin\-connectors internals.
+
+The vocabulary was lifted from irmin\-connectors/connectors/common, where it shipped first as the fix for a 10\-minute Stripe import that emitted zero log rows. Background: see irmin\-connectors/guides/how\-to\-create\-connectors.md.
+
+## Index
+
+- [Constants](<#constants>)
+- [type ProgressEvent](<#ProgressEvent>)
+- [type ProgressHandler](<#ProgressHandler>)
+
+
+## Constants
+
+<a name="ProgressKindPage"></a>ProgressKind\* enumerate the event types emitted via ProgressHandler. String values are part of the wire format and are intentionally stable across services and across language boundaries \(a TypeScript consumer in irmin\-ai uses these same string values\).
+
+```go
+const (
+    // ProgressKindPage fires after each successful list-page response
+    // in a paginated source (HTTP cursor, vector ID list, etc.).
+    ProgressKindPage = "page"
+    // ProgressKindRateLimit fires when a producer is about to sleep
+    // before retrying after a 429 / quota / backoff. Without this,
+    // rate-limit storms look identical to a silent hang.
+    ProgressKindRateLimit = "rate_limit"
+    // ProgressKindBatch fires after each chunk of a bulk upload.
+    ProgressKindBatch = "batch"
+    // ProgressKindQuery fires during a long-running SQL row-scan.
+    // Producers throttle their own emission — one row == one event
+    // would flood the sink.
+    ProgressKindQuery = "query"
+    // ProgressKindFile fires per file during a multi-file transfer.
+    ProgressKindFile = "file"
+    // ProgressKindHeartbeat is emitted by the sink-side handler at a
+    // fixed cadence (typically 30s) for the lifetime of the
+    // operation, even if the producer's ProgressHandler is nil. It's
+    // the floor of observability: no operation can ship a silent
+    // 10-minute gap, even by accident.
+    ProgressKindHeartbeat = "heartbeat"
+)
+```
+
+<a name="ProgressEvent"></a>
+## type ProgressEvent
+
+ProgressEvent is a single observability event emitted from a long\-running operation. Producers fire these into a ProgressHandler; the handler is responsible for turning them into the right output shape for its sink \(DB row, log line, stream event, etc.\).
+
+Not every field is meaningful for every Kind — see the field docs. The Kind discriminator selects which subset applies.
+
+```go
+type ProgressEvent struct {
+    // Kind discriminates the event. Use one of the ProgressKind*
+    // constants below.
+    Kind string
+
+    // ResourcePath is a human-readable identifier for what's being
+    // processed: an API path ("/v1/customers"), a table name
+    // ("public.orders"), a file path ("inbox/report.csv"), an
+    // index URI ("pinecone://my-index"). Should always be set so
+    // operators with multiple targets per workflow can disambiguate.
+    ResourcePath string
+
+    // Page is the 1-based page number within the current pagination
+    // loop.
+    Page int
+    // RecordsSoFar is the cumulative record count accumulated so far.
+    RecordsSoFar int
+    // Cursor is the cursor value that produced this page (e.g.,
+    // starting_after), or "" for the first page.
+    Cursor string
+
+    // Attempt is the 0-based retry attempt.
+    Attempt int
+    // Wait is how long the caller is about to sleep before retrying.
+    Wait time.Duration
+
+    // Batch is the 1-based batch index.
+    Batch int
+    // BatchSize is the number of records in this batch.
+    BatchSize int
+
+    // Rows is the cumulative number of rows processed.
+    Rows int64
+
+    // File is the file path currently being transferred.
+    File string
+    // BytesTransferred is the cumulative bytes moved for this
+    // operation (or for the current file — emitter decides).
+    BytesTransferred int64
+    // BytesTotal is the total expected bytes, or 0 if unknown.
+    BytesTotal int64
+}
+```
+
+<a name="ProgressHandler"></a>
+## type ProgressHandler
+
+ProgressHandler receives observability events from long\-running operations. Called synchronously from inside the producer's pagination / retry / transfer loops — implementations must return quickly. nil\-safe: producers whose operations are short\-running may pass nil.
+
+```go
+type ProgressHandler func(ProgressEvent)
+```
+
 # irminsqids
 
 ```go

--- a/docs/html/github_com_IrminData_irmin-sdk-go_observability.html
+++ b/docs/html/github_com_IrminData_irmin-sdk-go_observability.html
@@ -1,0 +1,118 @@
+<!doctype html>
+<html><head><meta charset="utf-8"/><title>github.com/IrminData/irmin-sdk-go/observability</title></head><body>
+<h1>Package github.com/IrminData/irmin-sdk-go/observability</h1>
+<pre>
+package observability // import "github.com/IrminData/irmin-sdk-go/observability"
+
+Package observability defines the shared progress-event vocabulary used across
+Irmin services and connectors. The types here are pure data — no database,
+no logger, no transport. Sink-aware helpers (e.g., emission to an OperationLog
+table or a stream response) live in the consuming service since the right sink
+differs per service:
+
+  - irmin-connectors emits to OperationLog rows via LogOperationProgress +
+    LogOperationEvent.
+  - irmin Core emits to WorkflowRun.Logs via WorkflowLogBuilder.
+  - irmin-ai emits as NDJSON stream events to the chat client.
+
+Centralising the vocabulary (kinds, event shape, handler signature) here keeps
+the operator-facing semantics consistent across those surfaces — a "page"
+event means the same thing in every service — and lets external connector
+authors building against this SDK reach the types directly without depending on
+irmin-connectors internals.
+
+The vocabulary was lifted from irmin-connectors/connectors/common, where it
+shipped first as the fix for a 10-minute Stripe import that emitted zero log
+rows. Background: see irmin-connectors/guides/how-to-create-connectors.md.
+
+CONSTANTS
+
+const (
+	// ProgressKindPage fires after each successful list-page response
+	// in a paginated source (HTTP cursor, vector ID list, etc.).
+	ProgressKindPage = "page"
+	// ProgressKindRateLimit fires when a producer is about to sleep
+	// before retrying after a 429 / quota / backoff. Without this,
+	// rate-limit storms look identical to a silent hang.
+	ProgressKindRateLimit = "rate_limit"
+	// ProgressKindBatch fires after each chunk of a bulk upload.
+	ProgressKindBatch = "batch"
+	// ProgressKindQuery fires during a long-running SQL row-scan.
+	// Producers throttle their own emission — one row == one event
+	// would flood the sink.
+	ProgressKindQuery = "query"
+	// ProgressKindFile fires per file during a multi-file transfer.
+	ProgressKindFile = "file"
+	// ProgressKindHeartbeat is emitted by the sink-side handler at a
+	// fixed cadence (typically 30s) for the lifetime of the
+	// operation, even if the producer's ProgressHandler is nil. It's
+	// the floor of observability: no operation can ship a silent
+	// 10-minute gap, even by accident.
+	ProgressKindHeartbeat = "heartbeat"
+)
+    ProgressKind* enumerate the event types emitted via ProgressHandler. String
+    values are part of the wire format and are intentionally stable across
+    services and across language boundaries (a TypeScript consumer in irmin-ai
+    uses these same string values).
+
+
+TYPES
+
+type ProgressEvent struct {
+	// Kind discriminates the event. Use one of the ProgressKind*
+	// constants below.
+	Kind string
+
+	// ResourcePath is a human-readable identifier for what's being
+	// processed: an API path ("/v1/customers"), a table name
+	// ("public.orders"), a file path ("inbox/report.csv"), an
+	// index URI ("pinecone://my-index"). Should always be set so
+	// operators with multiple targets per workflow can disambiguate.
+	ResourcePath string
+
+	// Page is the 1-based page number within the current pagination
+	// loop.
+	Page int
+	// RecordsSoFar is the cumulative record count accumulated so far.
+	RecordsSoFar int
+	// Cursor is the cursor value that produced this page (e.g.,
+	// starting_after), or "" for the first page.
+	Cursor string
+
+	// Attempt is the 0-based retry attempt.
+	Attempt int
+	// Wait is how long the caller is about to sleep before retrying.
+	Wait time.Duration
+
+	// Batch is the 1-based batch index.
+	Batch int
+	// BatchSize is the number of records in this batch.
+	BatchSize int
+
+	// Rows is the cumulative number of rows processed.
+	Rows int64
+
+	// File is the file path currently being transferred.
+	File string
+	// BytesTransferred is the cumulative bytes moved for this
+	// operation (or for the current file — emitter decides).
+	BytesTransferred int64
+	// BytesTotal is the total expected bytes, or 0 if unknown.
+	BytesTotal int64
+}
+    ProgressEvent is a single observability event emitted from a long-running
+    operation. Producers fire these into a ProgressHandler; the handler is
+    responsible for turning them into the right output shape for its sink (DB
+    row, log line, stream event, etc.).
+
+    Not every field is meaningful for every Kind — see the field docs. The Kind
+    discriminator selects which subset applies.
+
+type ProgressHandler func(ProgressEvent)
+    ProgressHandler receives observability events from long-running operations.
+    Called synchronously from inside the producer's pagination / retry /
+    transfer loops — implementations must return quickly. nil-safe: producers
+    whose operations are short-running may pass nil.
+
+</pre>
+</body></html>

--- a/docs/html/index.html
+++ b/docs/html/index.html
@@ -2,12 +2,13 @@
 <meta charset="utf-8"/>
 <title>github.com/IrminData/irmin-sdk-go documentation</title>
 <h1>github.com/IrminData/irmin-sdk-go documentation</h1>
-<p>Generated on 2026-04-18 16:28 UTC</p>
+<p>Generated on 2026-04-22 12:32 UTC</p>
 <ul>
 <li><a href="github_com_IrminData_irmin-sdk-go.html">github.com/IrminData/irmin-sdk-go</a></li>
 <li><a href="github_com_IrminData_irmin-sdk-go_api.html">github.com/IrminData/irmin-sdk-go/api</a></li>
 <li><a href="github_com_IrminData_irmin-sdk-go_duckdb.html">github.com/IrminData/irmin-sdk-go/duckdb</a></li>
 <li><a href="github_com_IrminData_irmin-sdk-go_models.html">github.com/IrminData/irmin-sdk-go/models</a></li>
+<li><a href="github_com_IrminData_irmin-sdk-go_observability.html">github.com/IrminData/irmin-sdk-go/observability</a></li>
 <li><a href="github_com_IrminData_irmin-sdk-go_sqids.html">github.com/IrminData/irmin-sdk-go/sqids</a></li>
 <li><a href="github_com_IrminData_irmin-sdk-go_utils.html">github.com/IrminData/irmin-sdk-go/utils</a></li>
 <li><a href="github_com_IrminData_irmin-sdk-go_validator.html">github.com/IrminData/irmin-sdk-go/validator</a></li>

--- a/observability/progress.go
+++ b/observability/progress.go
@@ -1,0 +1,119 @@
+// Package observability defines the shared progress-event vocabulary
+// used across Irmin services and connectors. The types here are pure
+// data — no database, no logger, no transport. Sink-aware helpers
+// (e.g., emission to an OperationLog table or a stream response) live
+// in the consuming service since the right sink differs per service:
+//
+//   - irmin-connectors emits to OperationLog rows via
+//     LogOperationProgress + LogOperationEvent.
+//   - irmin Core emits to WorkflowRun.Logs via WorkflowLogBuilder.
+//   - irmin-ai emits as NDJSON stream events to the chat client.
+//
+// Centralising the vocabulary (kinds, event shape, handler signature)
+// here keeps the operator-facing semantics consistent across those
+// surfaces — a "page" event means the same thing in every service —
+// and lets external connector authors building against this SDK reach
+// the types directly without depending on irmin-connectors internals.
+//
+// The vocabulary was lifted from irmin-connectors/connectors/common,
+// where it shipped first as the fix for a 10-minute Stripe import
+// that emitted zero log rows. Background:
+// see irmin-connectors/guides/how-to-create-connectors.md.
+package observability
+
+import "time"
+
+// ProgressEvent is a single observability event emitted from a
+// long-running operation. Producers fire these into a ProgressHandler;
+// the handler is responsible for turning them into the right output
+// shape for its sink (DB row, log line, stream event, etc.).
+//
+// Not every field is meaningful for every Kind — see the field docs.
+// The Kind discriminator selects which subset applies.
+type ProgressEvent struct {
+	// Kind discriminates the event. Use one of the ProgressKind*
+	// constants below.
+	Kind string
+
+	// ResourcePath is a human-readable identifier for what's being
+	// processed: an API path ("/v1/customers"), a table name
+	// ("public.orders"), a file path ("inbox/report.csv"), an
+	// index URI ("pinecone://my-index"). Should always be set so
+	// operators with multiple targets per workflow can disambiguate.
+	ResourcePath string
+
+	// --- Pagination (ProgressKindPage) ---
+
+	// Page is the 1-based page number within the current pagination
+	// loop.
+	Page int
+	// RecordsSoFar is the cumulative record count accumulated so far.
+	RecordsSoFar int
+	// Cursor is the cursor value that produced this page (e.g.,
+	// starting_after), or "" for the first page.
+	Cursor string
+
+	// --- Retry / rate-limit (ProgressKindRateLimit) ---
+
+	// Attempt is the 0-based retry attempt.
+	Attempt int
+	// Wait is how long the caller is about to sleep before retrying.
+	Wait time.Duration
+
+	// --- Chunked upload (ProgressKindBatch) ---
+
+	// Batch is the 1-based batch index.
+	Batch int
+	// BatchSize is the number of records in this batch.
+	BatchSize int
+
+	// --- SQL query progress (ProgressKindQuery) ---
+
+	// Rows is the cumulative number of rows processed.
+	Rows int64
+
+	// --- File transfer (ProgressKindFile) ---
+
+	// File is the file path currently being transferred.
+	File string
+	// BytesTransferred is the cumulative bytes moved for this
+	// operation (or for the current file — emitter decides).
+	BytesTransferred int64
+	// BytesTotal is the total expected bytes, or 0 if unknown.
+	BytesTotal int64
+}
+
+// ProgressKind* enumerate the event types emitted via ProgressHandler.
+// String values are part of the wire format and are intentionally
+// stable across services and across language boundaries (a
+// TypeScript consumer in irmin-ai uses these same string values).
+const (
+	// ProgressKindPage fires after each successful list-page response
+	// in a paginated source (HTTP cursor, vector ID list, etc.).
+	ProgressKindPage = "page"
+	// ProgressKindRateLimit fires when a producer is about to sleep
+	// before retrying after a 429 / quota / backoff. Without this,
+	// rate-limit storms look identical to a silent hang.
+	ProgressKindRateLimit = "rate_limit"
+	// ProgressKindBatch fires after each chunk of a bulk upload.
+	ProgressKindBatch = "batch"
+	// ProgressKindQuery fires during a long-running SQL row-scan.
+	// Producers throttle their own emission — one row == one event
+	// would flood the sink.
+	ProgressKindQuery = "query"
+	// ProgressKindFile fires per file during a multi-file transfer.
+	ProgressKindFile = "file"
+	// ProgressKindHeartbeat is emitted by the sink-side handler at a
+	// fixed cadence (typically 30s) for the lifetime of the
+	// operation, even if the producer's ProgressHandler is nil. It's
+	// the floor of observability: no operation can ship a silent
+	// 10-minute gap, even by accident.
+	ProgressKindHeartbeat = "heartbeat"
+)
+
+// ProgressHandler receives observability events from long-running
+// operations. Called synchronously from inside the producer's
+// pagination / retry / transfer loops — implementations must return
+// quickly. nil-safe: producers whose operations are short-running may
+// pass nil.
+type ProgressHandler func(ProgressEvent)

--- a/observability/progress_test.go
+++ b/observability/progress_test.go
@@ -1,0 +1,65 @@
+package observability_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/IrminData/irmin-sdk-go/observability"
+)
+
+// TestProgressKind_WireFormat pins the string values of the kind
+// constants. They are part of the cross-language wire format —
+// irmin-ai's TypeScript consumer matches these by value — so a
+// rename here is a breaking change to every consumer at once.
+func TestProgressKind_WireFormat(t *testing.T) {
+	cases := map[string]string{
+		observability.ProgressKindPage:      "page",
+		observability.ProgressKindRateLimit: "rate_limit",
+		observability.ProgressKindBatch:     "batch",
+		observability.ProgressKindQuery:     "query",
+		observability.ProgressKindFile:      "file",
+		observability.ProgressKindHeartbeat: "heartbeat",
+	}
+	for got, want := range cases {
+		if got != want {
+			t.Errorf("kind constant changed value: got %q, want %q", got, want)
+		}
+	}
+}
+
+// TestProgressHandler_Invocation verifies the function-type signature
+// is callable as expected — producers all use the same `if h != nil
+// { h(event) }` guard pattern, so the type must accept ProgressEvent
+// and return nothing.
+func TestProgressHandler_Invocation(t *testing.T) {
+	var calls int
+	h := observability.ProgressHandler(func(observability.ProgressEvent) { calls++ })
+	h(observability.ProgressEvent{Kind: observability.ProgressKindHeartbeat})
+	h(observability.ProgressEvent{Kind: observability.ProgressKindPage, Page: 1})
+	if calls != 2 {
+		t.Errorf("handler invocations: got %d, want 2", calls)
+	}
+}
+
+// TestProgressEvent_FieldsAccessible is a smoke test that every
+// per-kind field is reachable as a public struct field. If a future
+// refactor accidentally unexports one, this fails to compile —
+// catching the API break at SDK build time, not at downstream
+// consumer build time.
+func TestProgressEvent_FieldsAccessible(_ *testing.T) {
+	_ = observability.ProgressEvent{
+		Kind:             observability.ProgressKindFile,
+		ResourcePath:     "sftp://host:22",
+		Page:             1,
+		RecordsSoFar:     100,
+		Cursor:           "tok",
+		Attempt:          0,
+		Wait:             time.Second,
+		Batch:            1,
+		BatchSize:        100,
+		Rows:             1000,
+		File:             "report.csv",
+		BytesTransferred: 2048,
+		BytesTotal:       4096,
+	}
+}


### PR DESCRIPTION
## Summary

Foundation for extending the [progress-events pattern](https://github.com/IrminData/irmin-connectors/pull/164) beyond \`irmin-connectors\`. Lifts the pure-vocabulary types (\`ProgressEvent\`, \`ProgressKind*\`, \`ProgressHandler\`) out of [\`connectors/common/progress.go\`](https://github.com/IrminData/irmin-connectors/blob/main/connectors/common/progress.go) so:

- **`irmin/` Core** can adopt them for workflow-log heartbeats and DuckDB query progress (Phase B of the rollout).
- **`irmin-ai/`** can mirror the same kind taxonomy in TypeScript for stream-event progress (Phase C).
- **External connector authors** building against the SDK can reach the types directly without depending on \`irmin-connectors\` internals.

## What's in / what's out

**In:** Pure types only — \`ProgressEvent\` struct, \`ProgressKind*\` constants, \`ProgressHandler\` function type. Zero dependencies. Mirrors the precedent of [\`models/log.go\`](models/log.go) hosting \`LogEvent\`/\`LogEventType\`.

**Out:** Sink-aware helpers (\`NewProgressHandler\`, \`LogOperationProgress\`, \`ThrottledQueryEmitter\`, \`startHeartbeat\`) stay in \`irmin-connectors/connectors/common\` since they depend on the connectors-side \`*db.Database\` type. Core gets its own equivalents in Phase B that wrap \`WorkflowLogBuilder\`.

## Cross-language wire format

The kind string values (\`page\`, \`rate_limit\`, \`batch\`, \`query\`, \`file\`, \`heartbeat\`) are stable across language boundaries. The Phase C TypeScript consumer in \`irmin-ai/\` will match by value. \`TestProgressKind_WireFormat\` pins them so a rename in this package fails SDK build before it breaks downstream consumers.

## Test plan

- [x] \`go build ./...\` — clean
- [x] \`go test ./observability/...\` — passes (3 tests)
- [x] \`golangci-lint run ./observability/...\` — 0 issues

## Followups

After this lands + tags:
- Bump \`irmin-connectors\` to the new SDK tag and replace its local type defs with type aliases. Zero-cost backward compat for every existing connector.
- \`irmin/\` Core picks up the SDK and adds workflow-log heartbeat (Phase B).
- \`irmin-ai/\` mirrors the kind taxonomy in TypeScript (Phase C).

Plan doc: [bake-progress-event-observability-into-distributed-thimble.md](https://github.com/IrminData/irmin-connectors/blob/main/.claude/plans/bake-progress-event-observability-into-distributed-thimble.md) (private).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a new standalone package plus documentation, with no changes to existing runtime logic; main risk is introducing a new public API surface whose kind string values must remain stable.
> 
> **Overview**
> Introduces a new `observability` package that centralizes a shared progress-event vocabulary (`ProgressEvent`, `ProgressHandler`, and stable `ProgressKind*` string constants) for reporting long-running operation progress across services.
> 
> Updates the README and generated docs to document the new package and adds tests that pin the kind wire-format strings and ensure the public API remains callable/accessible.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 21d1acfcb60309594d234b8534b97edd27d709d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->