### PR TITLE
feat(connectorsclient): async pull protocol types and client

### DIFF
--- a/connectorsclient/client.go
+++ b/connectorsclient/client.go
@@ -1,0 +1,103 @@
+package connectorsclient
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+
+	irminsdkgo "github.com/IrminData/irmin-sdk-go"
+)
+
+// HeaderConnectionID is sent on every outbound connector request so
+// the receiving service can identify which Irmin Connection the
+// operation belongs to. The value mirrors the exact string used by
+// the existing Core-side connectors-client so migration is a drop-in.
+//
+// Using Go's canonical HTTP header form avoids net/http silently
+// rewriting it at send time and keeps reads consistent.
+const HeaderConnectionID = "X-Irmin-Connection-Id"
+
+// Client is the async-protocol connector-service HTTP client.
+//
+// A Client is safe for concurrent use. It keeps two underlying
+// http.Clients: one for short request/response calls (status, start,
+// cancel) and one without a top-level timeout for the streaming
+// result fetch, so long zip downloads are not cut off by the
+// request-response timer.
+type Client struct {
+	// BaseURL is the connector service base, e.g.
+	// "https://connectors.irmin.dev/stripe". It must include the
+	// connector-specific prefix the service expects.
+	BaseURL string
+
+	// Token is the operation or system token for the connector,
+	// set on the Authorization header as "Bearer <token>".
+	Token string
+
+	// Locale is used to request localised messages from the
+	// connector service via the Accept-Language header.
+	Locale string
+
+	// HTTPClient is the client used for short requests (start,
+	// status, cancel). Defaults to a client with
+	// irminsdkgo.DefaultConnectorTimeout. Callers that need custom
+	// transports, proxies, or timeouts may replace it.
+	HTTPClient *http.Client
+
+	// streamClient is used for /operation/result reads. It
+	// intentionally has no top-level Timeout so large zip downloads
+	// are not aborted by the response-level timer; lifecycle is
+	// instead tied to the request context.
+	streamClient *http.Client
+
+	// ConnectionID is the Irmin Connection ID this client is
+	// operating on behalf of. When non-zero it is sent as
+	// HeaderConnectionID on every outbound request so OAuth-backed
+	// connectors can fetch the right access token. Leave zero for
+	// calls that are not connection-scoped.
+	ConnectionID uint
+}
+
+// NewClient creates a new connector-service client with sensible
+// default http.Client settings. The two underlying clients share a
+// single transport so connection pooling and TLS sessions are
+// reused across short and streaming calls.
+func NewClient(baseURL, token, locale string) *Client {
+	transport := http.DefaultTransport
+	return &Client{
+		BaseURL: baseURL,
+		Token:   token,
+		Locale:  locale,
+		HTTPClient: &http.Client{
+			Timeout:   irminsdkgo.DefaultConnectorTimeout,
+			Transport: transport,
+		},
+		streamClient: &http.Client{Transport: transport},
+	}
+}
+
+// WithConnectionID returns the receiver after setting ConnectionID,
+// enabling a fluent call-site:
+//
+//	client := connectorsclient.NewClient(url, tok, "en").WithConnectionID(conn.ID)
+//
+// Mutates and returns the same pointer. Passing 0 clears the
+// connection context.
+func (c *Client) WithConnectionID(id uint) *Client {
+	c.ConnectionID = id
+	return c
+}
+
+// applyDefaultHeaders sets the headers common to every request this
+// client issues: auth, locale, the optional connection ID, and a
+// caller-supplied Accept if the caller did not set one.
+func (c *Client) applyDefaultHeaders(req *http.Request, accept string) {
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.Token))
+	req.Header.Set("Accept-Language", c.Locale)
+	if req.Header.Get("Accept") == "" && accept != "" {
+		req.Header.Set("Accept", accept)
+	}
+	if c.ConnectionID != 0 {
+		req.Header.Set(HeaderConnectionID, strconv.FormatUint(uint64(c.ConnectionID), 10))
+	}
+}

--- a/connectorsclient/doc.go
+++ b/connectorsclient/doc.go
@@ -1,0 +1,24 @@
+// Package connectorsclient is the Irmin SDK client for the
+// connector-service HTTP plugin protocol.
+//
+// At present the package intentionally covers only the asynchronous
+// pull protocol — POST /operation/pull (202 + job_id), GET
+// /operation/status/:job_id, GET /operation/result/:job_id, and
+// POST /operation/cancel/:job_id — because that is the surface Core
+// needs to stop buffering large zips in memory and avoid Railway's
+// ~300s edge timeout on long Stripe / Pinecone / Postgres pulls.
+//
+// Core today has an in-repo connectors-client with the full set of
+// synchronous endpoints (init, pull, push, patch, subscribe, etc.).
+// Migration plan:
+//
+//  1. SDK publishes these async types + methods (this package).
+//  2. Core's in-repo client switches to depend on these for the
+//     async endpoints, keeping the existing sync helpers for
+//     everything else.
+//  3. Remaining helpers move into this SDK package incrementally.
+//
+// Consumers that only need the async protocol (tests, tooling) can
+// use this package standalone. It carries no transitive dependency
+// on Core or the connectors service beyond the shared SDK models.
+package connectorsclient

--- a/connectorsclient/errors.go
+++ b/connectorsclient/errors.go
@@ -1,0 +1,86 @@
+package connectorsclient
+
+import (
+	"errors"
+	"fmt"
+
+	irminmodels "github.com/IrminData/irmin-sdk-go/models"
+)
+
+// APIError is returned when the connector service responds with an
+// unexpected HTTP status code. Callers can inspect StatusCode and
+// Body for diagnostics, or use errors.As to unwrap it from wrapped
+// errors.
+type APIError struct {
+	// StatusCode is the HTTP status returned by the connector.
+	StatusCode int
+	// Body is the response body (may be JSON, may be plain text)
+	// captured verbatim for diagnostics.
+	Body string
+}
+
+// Error implements the error interface.
+func (e *APIError) Error() string {
+	return fmt.Sprintf(
+		"connector API request failed with status %d. Body: %s",
+		e.StatusCode,
+		e.Body,
+	)
+}
+
+// ErrLegacySyncPullResponse is returned by StartOperationPull when
+// the connector service responds with a 200 OK + zip body instead of
+// the expected 202 Accepted + {job_id}. Its presence means the
+// connector service is still on the pre-async protocol and the
+// caller is talking to an unmigrated deployment; the Core poll
+// wrapper should bail out with an actionable message rather than
+// attempt a silent fallback, per the "no backward-compat shim"
+// decision in the async-pull plan.
+var ErrLegacySyncPullResponse = errors.New(
+	"connector returned legacy synchronous pull response (HTTP 200 with body); " +
+		"expected 202 Accepted from async protocol — upgrade the connector service",
+)
+
+// ErrResultNotReady is returned by FetchOperationResult when the job
+// is still in a non-terminal state (pending or running) at the time
+// of the fetch. The Core poll wrapper should only call
+// FetchOperationResult after observing status=complete; this error
+// surfaces a protocol mistake rather than a transient condition and
+// is not safe to retry without polling status again.
+var ErrResultNotReady = errors.New(
+	"operation result is not ready: job has not reached terminal status=complete",
+)
+
+// ErrJobFailed is returned when a status response indicates the job
+// has reached a non-success terminal state (failed or cancelled).
+// Callers that wrap this can surface the original connector-supplied
+// error message from OperationJobStatusResponse.Error.
+var ErrJobFailed = errors.New("operation job ended in a non-success terminal state")
+
+// JobFailedError wraps ErrJobFailed with the terminal status and the
+// connector-supplied error message, so callers that wish to act on
+// cancelled vs. failed can discriminate without re-reading the
+// status response.
+type JobFailedError struct {
+	// Status is the terminal status observed. Always
+	// OperationJobStatusFailed or OperationJobStatusCancelled.
+	Status irminmodels.OperationJobStatus
+	// Message is the operator-facing error message from the status
+	// response. May be empty for cancellations.
+	Message string
+}
+
+// Error implements the error interface.
+func (e *JobFailedError) Error() string {
+	if e.Message == "" {
+		return fmt.Sprintf("operation job ended with status=%s", e.Status)
+	}
+	return fmt.Sprintf("operation job ended with status=%s: %s", e.Status, e.Message)
+}
+
+// Unwrap lets errors.Is(err, ErrJobFailed) succeed on wrapped
+// JobFailedError values, so callers can check the sentinel and then
+// use errors.As to extract the detail.
+func (e *JobFailedError) Unwrap() error {
+	return ErrJobFailed
+}

--- a/connectorsclient/operation_async.go
+++ b/connectorsclient/operation_async.go
@@ -186,8 +186,11 @@ func (c *Client) FetchOperationResult(
 
 	// 409 signals "not ready". Drain+close the body so the
 	// connection can be reused, then surface the typed error.
+	// Bounded drain — streamClient has no top-level timeout, so a
+	// misbehaving server sending an unbounded 409 body would otherwise
+	// hang this path. errorBodyReadLimit matches readAPIError's guard.
 	if resp.StatusCode == http.StatusConflict {
-		_, _ = io.Copy(io.Discard, resp.Body)
+		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, errorBodyReadLimit))
 		_ = resp.Body.Close()
 		return nil, ErrResultNotReady
 	}

--- a/connectorsclient/operation_async.go
+++ b/connectorsclient/operation_async.go
@@ -1,0 +1,275 @@
+package connectorsclient
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+
+	irminmodels "github.com/IrminData/irmin-sdk-go/models"
+)
+
+// StartOperationPullRequest holds the payload for POST /operation/pull
+// under the async protocol. It intentionally uses the same
+// x-www-form-urlencoded surface as the pre-async handler so the
+// server-side route signature does not churn; only the response
+// shape changes (202 + {job_id} instead of a streamed zip body).
+type StartOperationPullRequest struct {
+	// Path is the connector-specific resource path being pulled
+	// (e.g., "/v1/customers" for Stripe, a table identifier for
+	// Postgres). Required.
+	Path string
+
+	// Extra carries any additional form fields the specific
+	// connector accepts on its pull endpoint (cursor, filters,
+	// batch hints). Use for connector-specific parameters — the
+	// shared SDK types cannot enumerate every connector's knobs.
+	Extra map[string]string
+}
+
+// StartOperationPull initiates an asynchronous pull against a
+// connector. It expects the connector service to respond with
+// 202 Accepted and {job_id, ...}; the returned
+// StartOperationPullResponse carries that job_id, which the caller
+// then uses to poll status and, eventually, fetch the result.
+//
+// On HTTP 200 (legacy synchronous response) this returns
+// ErrLegacySyncPullResponse without attempting to drain the body —
+// per the async-pull plan there is intentionally no sync fallback,
+// and surfacing a specific error lets the Core poll wrapper print
+// an actionable message rather than silently degrade.
+//
+// Any other non-2xx status returns an *APIError.
+func (c *Client) StartOperationPull(
+	ctx context.Context,
+	req StartOperationPullRequest,
+) (*irminmodels.StartOperationPullResponse, error) {
+	body, headers := encodeStartPullForm(req)
+
+	httpReq, err := http.NewRequestWithContext(
+		ctx,
+		http.MethodPost,
+		c.BaseURL+"/operation/pull",
+		body,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build start pull request: %w", err)
+	}
+	for k, v := range headers {
+		httpReq.Header.Set(k, v)
+	}
+	c.applyDefaultHeaders(httpReq, "application/json")
+
+	resp, err := c.HTTPClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("start pull request to %s failed: %w", httpReq.URL, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	// Legacy sync servers return 200 with the zip body. Don't drain
+	// the body — it can be gigabytes. Bail with the sentinel so the
+	// poll wrapper can emit an actionable operator message.
+	if resp.StatusCode == http.StatusOK {
+		return nil, ErrLegacySyncPullResponse
+	}
+
+	if resp.StatusCode != http.StatusAccepted {
+		return nil, readAPIError(resp)
+	}
+
+	bodyBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read start pull response body: %w", err)
+	}
+
+	var out irminmodels.StartOperationPullResponse
+	if unmarshalErr := json.Unmarshal(bodyBytes, &out); unmarshalErr != nil {
+		return nil, fmt.Errorf("failed to unmarshal start pull response: %w", unmarshalErr)
+	}
+	if out.JobID == "" {
+		return nil, errors.New(
+			"connector accepted the pull (HTTP 202) but did not return a job_id",
+		)
+	}
+	return &out, nil
+}
+
+// GetOperationJobStatus polls the status of an async operation job.
+// Safe to call repeatedly; the Core side drives a poll loop at
+// roughly 5s cadence. Progress events on the response are cumulative,
+// so consumers may either diff against a previously seen slice or
+// replace their local view wholesale.
+//
+// The caller should stop polling once the returned Status satisfies
+// OperationJobStatus.IsTerminal.
+func (c *Client) GetOperationJobStatus(
+	ctx context.Context,
+	jobID string,
+) (*irminmodels.OperationJobStatusResponse, error) {
+	if jobID == "" {
+		return nil, errors.New("jobID must not be empty")
+	}
+
+	endpoint := fmt.Sprintf("%s/operation/status/%s", c.BaseURL, url.PathEscape(jobID))
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build status request: %w", err)
+	}
+	c.applyDefaultHeaders(httpReq, "application/json")
+
+	resp, err := c.HTTPClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("status request to %s failed: %w", httpReq.URL, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, readAPIError(resp)
+	}
+
+	bodyBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read status response body: %w", err)
+	}
+
+	var out irminmodels.OperationJobStatusResponse
+	if unmarshalErr := json.Unmarshal(bodyBytes, &out); unmarshalErr != nil {
+		return nil, fmt.Errorf("failed to unmarshal status response: %w", unmarshalErr)
+	}
+	return &out, nil
+}
+
+// FetchOperationResult streams the result archive (zip) for a
+// completed async operation job. The caller is responsible for
+// closing the returned io.ReadCloser — the connection stays open
+// until the caller drains or closes it, and the request context
+// governs the transfer lifetime.
+//
+// The body is intentionally not buffered into memory; this is the
+// whole point of the async protocol. Callers should pipe the
+// reader directly into their downstream processing (archive
+// extraction, re-upload to LakeFS, etc.) so the zip never lands
+// fully on either peer.
+//
+// Semantics by response status:
+//
+//   - 200 OK with application/zip (or any non-JSON) body: returns
+//     the body reader.
+//   - 409 Conflict: the job is not yet in terminal state complete.
+//     Returns ErrResultNotReady; callers should resume polling
+//     status rather than retry the result fetch.
+//   - Any other non-2xx: returns *APIError.
+func (c *Client) FetchOperationResult(
+	ctx context.Context,
+	jobID string,
+) (io.ReadCloser, error) {
+	if jobID == "" {
+		return nil, errors.New("jobID must not be empty")
+	}
+
+	endpoint := fmt.Sprintf("%s/operation/result/%s", c.BaseURL, url.PathEscape(jobID))
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build result request: %w", err)
+	}
+	c.applyDefaultHeaders(httpReq, "application/zip")
+
+	resp, err := c.streamClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("result request to %s failed: %w", httpReq.URL, err)
+	}
+
+	// 409 signals "not ready". Drain+close the body so the
+	// connection can be reused, then surface the typed error.
+	if resp.StatusCode == http.StatusConflict {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		_ = resp.Body.Close()
+		return nil, ErrResultNotReady
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		apiErr := readAPIError(resp)
+		_ = resp.Body.Close()
+		return nil, apiErr
+	}
+
+	// Success — hand the live body to the caller. They own Close.
+	return resp.Body, nil
+}
+
+// CancelOperationJob requests that the connector service cancel an
+// in-flight async operation job. Safe to call on terminal jobs
+// (server is expected to treat it as a no-op). Uses POST with the
+// job_id on the path so it composes with existing per-job routes.
+func (c *Client) CancelOperationJob(ctx context.Context, jobID string) error {
+	if jobID == "" {
+		return errors.New("jobID must not be empty")
+	}
+
+	endpoint := fmt.Sprintf("%s/operation/cancel/%s", c.BaseURL, url.PathEscape(jobID))
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, nil)
+	if err != nil {
+		return fmt.Errorf("failed to build cancel request: %w", err)
+	}
+	c.applyDefaultHeaders(httpReq, "application/json")
+
+	resp, err := c.HTTPClient.Do(httpReq)
+	if err != nil {
+		return fmt.Errorf("cancel request to %s failed: %w", httpReq.URL, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return readAPIError(resp)
+	}
+	// Response body (if any) is ignored — cancel is fire-and-forget.
+	_, _ = io.Copy(io.Discard, resp.Body)
+	return nil
+}
+
+// encodeStartPullForm renders a StartOperationPullRequest as
+// application/x-www-form-urlencoded body + the matching headers.
+// Keeps the request surface identical to the pre-async
+// /operation/pull handler so the server-side route does not change
+// shape.
+func encodeStartPullForm(req StartOperationPullRequest) (io.Reader, map[string]string) {
+	values := url.Values{}
+	values.Set("path", req.Path)
+	for k, v := range req.Extra {
+		// Protect against a caller overwriting path via Extra.
+		if k == "path" {
+			continue
+		}
+		values.Set(k, v)
+	}
+	body := strings.NewReader(values.Encode())
+	headers := map[string]string{
+		"Content-Type": "application/x-www-form-urlencoded",
+	}
+	return body, headers
+}
+
+// errorBodyReadLimit is the upper bound on how many bytes of a
+// non-success response body we read into APIError.Body. Connector
+// errors are small JSON / plain-text payloads in practice; this cap
+// stops a pathological server from feeding an unbounded body into
+// the client's memory via an error path.
+const errorBodyReadLimit = 1 << 20 // 1 MiB
+
+// readAPIError builds an *APIError by reading whatever body the
+// connector returned for the current response. Consumes the body;
+// the caller is still responsible for closing it (we keep this
+// separate so cancel/status paths can control their own cleanup).
+func readAPIError(resp *http.Response) error {
+	var buf bytes.Buffer
+	_, _ = io.Copy(&buf, io.LimitReader(resp.Body, errorBodyReadLimit))
+	return &APIError{
+		StatusCode: resp.StatusCode,
+		Body:       buf.String(),
+	}
+}

--- a/connectorsclient/operation_async_test.go
+++ b/connectorsclient/operation_async_test.go
@@ -1,0 +1,352 @@
+package connectorsclient_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/IrminData/irmin-sdk-go/connectorsclient"
+	irminmodels "github.com/IrminData/irmin-sdk-go/models"
+	"github.com/IrminData/irmin-sdk-go/observability"
+)
+
+// TestStartOperationPull_HappyPath verifies the 202 + job_id path.
+// Also asserts that Authorization / Accept-Language / the connection
+// header are stamped on the outbound request, so a future refactor
+// that drops applyDefaultHeaders is caught here.
+func TestStartOperationPull_HappyPath(t *testing.T) {
+	var (
+		gotPath       string
+		gotAuth       string
+		gotLocale     string
+		gotConnection string
+	)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/operation/pull" {
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("ParseForm: %v", err)
+		}
+		gotPath = r.FormValue("path")
+		gotAuth = r.Header.Get("Authorization")
+		gotLocale = r.Header.Get("Accept-Language")
+		gotConnection = r.Header.Get(connectorsclient.HeaderConnectionID)
+
+		w.WriteHeader(http.StatusAccepted)
+		_ = json.NewEncoder(w).Encode(irminmodels.StartOperationPullResponse{JobID: "opjob_test123"})
+	}))
+	defer srv.Close()
+
+	c := connectorsclient.NewClient(srv.URL, "tok_abc", "en").WithConnectionID(42)
+
+	resp, err := c.StartOperationPull(context.Background(), connectorsclient.StartOperationPullRequest{
+		Path:  "/v1/customers",
+		Extra: map[string]string{"cursor": "abc"},
+	})
+	if err != nil {
+		t.Fatalf("StartOperationPull: %v", err)
+	}
+	if resp.JobID != "opjob_test123" {
+		t.Errorf("JobID = %q, want opjob_test123", resp.JobID)
+	}
+	if gotPath != "/v1/customers" {
+		t.Errorf("form path = %q, want /v1/customers", gotPath)
+	}
+	if gotAuth != "Bearer tok_abc" {
+		t.Errorf("Authorization = %q, want Bearer tok_abc", gotAuth)
+	}
+	if gotLocale != "en" {
+		t.Errorf("Accept-Language = %q, want en", gotLocale)
+	}
+	if gotConnection != "42" {
+		t.Errorf("%s = %q, want 42", connectorsclient.HeaderConnectionID, gotConnection)
+	}
+}
+
+// TestStartOperationPull_LegacySyncResponse verifies that a 200 OK
+// from an unmigrated connector surfaces the ErrLegacySyncPullResponse
+// sentinel rather than silently degrading to a sync path.
+func TestStartOperationPull_LegacySyncResponse(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/zip")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("PK\x03\x04 fake zip bytes"))
+	}))
+	defer srv.Close()
+
+	c := connectorsclient.NewClient(srv.URL, "tok", "en")
+	_, err := c.StartOperationPull(
+		context.Background(),
+		connectorsclient.StartOperationPullRequest{Path: "/v1/customers"},
+	)
+	if !errors.Is(err, connectorsclient.ErrLegacySyncPullResponse) {
+		t.Fatalf("err = %v, want ErrLegacySyncPullResponse", err)
+	}
+}
+
+// TestStartOperationPull_NonAcceptedStatus verifies that a non-202,
+// non-200 response surfaces as an *APIError carrying the status and
+// body for operator diagnostics.
+func TestStartOperationPull_NonAcceptedStatus(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte("boom"))
+	}))
+	defer srv.Close()
+
+	c := connectorsclient.NewClient(srv.URL, "tok", "en")
+	_, err := c.StartOperationPull(context.Background(), connectorsclient.StartOperationPullRequest{Path: "/x"})
+
+	var apiErr *connectorsclient.APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("err = %v, want *APIError", err)
+	}
+	if apiErr.StatusCode != http.StatusInternalServerError {
+		t.Errorf("StatusCode = %d, want 500", apiErr.StatusCode)
+	}
+	if apiErr.Body != "boom" {
+		t.Errorf("Body = %q, want boom", apiErr.Body)
+	}
+}
+
+// TestStartOperationPull_AcceptedButNoJobID verifies that the
+// defensive "no job_id" path triggers a descriptive error; server-side
+// bugs would otherwise silently return an empty-job client to Core.
+func TestStartOperationPull_AcceptedButNoJobID(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusAccepted)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer srv.Close()
+
+	c := connectorsclient.NewClient(srv.URL, "tok", "en")
+	_, err := c.StartOperationPull(context.Background(), connectorsclient.StartOperationPullRequest{Path: "/x"})
+	if err == nil || !strings.Contains(err.Error(), "did not return a job_id") {
+		t.Fatalf("err = %v, want missing-job_id error", err)
+	}
+}
+
+// TestGetOperationJobStatus_Transitions walks through the expected
+// pending → running → complete transitions a Core poll loop will see.
+// Ensures each intermediate status deserialises correctly and that
+// progress events use the shared observability vocabulary.
+func TestGetOperationJobStatus_Transitions(t *testing.T) {
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasPrefix(r.URL.Path, "/operation/status/") {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		n := atomic.AddInt32(&calls, 1)
+		var status irminmodels.OperationJobStatus
+		var progress []observability.ProgressEvent
+		switch n {
+		case 1:
+			status = irminmodels.OperationJobStatusPending
+		case 2:
+			status = irminmodels.OperationJobStatusRunning
+			progress = []observability.ProgressEvent{
+				{Kind: observability.ProgressKindPage, ResourcePath: "/v1/customers", Page: 1, RecordsSoFar: 100},
+			}
+		default:
+			status = irminmodels.OperationJobStatusComplete
+		}
+		_ = json.NewEncoder(w).Encode(irminmodels.OperationJobStatusResponse{
+			JobID:    "opjob_test123",
+			Status:   status,
+			Progress: progress,
+		})
+	}))
+	defer srv.Close()
+
+	c := connectorsclient.NewClient(srv.URL, "tok", "en")
+	ctx := context.Background()
+	wantStatuses := []irminmodels.OperationJobStatus{
+		irminmodels.OperationJobStatusPending,
+		irminmodels.OperationJobStatusRunning,
+		irminmodels.OperationJobStatusComplete,
+	}
+	for i, want := range wantStatuses {
+		got, err := c.GetOperationJobStatus(ctx, "opjob_test123")
+		if err != nil {
+			t.Fatalf("call %d: GetOperationJobStatus: %v", i, err)
+		}
+		if got.Status != want {
+			t.Errorf("call %d: Status = %q, want %q", i, got.Status, want)
+		}
+		if want == irminmodels.OperationJobStatusRunning {
+			if len(got.Progress) != 1 || got.Progress[0].Kind != observability.ProgressKindPage {
+				t.Errorf("call %d: missing expected page progress event: %+v", i, got.Progress)
+			}
+		}
+		if want.IsTerminal() != got.Status.IsTerminal() {
+			t.Errorf("IsTerminal() disagreement for %q", want)
+		}
+	}
+}
+
+// TestGetOperationJobStatus_Failed verifies that a failed job surfaces
+// its error message on the response intact, so Core can wrap it with
+// JobFailedError at the poll-loop level.
+func TestGetOperationJobStatus_Failed(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(irminmodels.OperationJobStatusResponse{
+			JobID:  "opjob_test123",
+			Status: irminmodels.OperationJobStatusFailed,
+			Error:  "stripe API returned 401 Unauthorized",
+		})
+	}))
+	defer srv.Close()
+
+	c := connectorsclient.NewClient(srv.URL, "tok", "en")
+	got, err := c.GetOperationJobStatus(context.Background(), "opjob_test123")
+	if err != nil {
+		t.Fatalf("GetOperationJobStatus: %v", err)
+	}
+	if got.Status != irminmodels.OperationJobStatusFailed {
+		t.Errorf("Status = %q, want failed", got.Status)
+	}
+	if got.Error != "stripe API returned 401 Unauthorized" {
+		t.Errorf("Error = %q, want stripe API message", got.Error)
+	}
+	if !got.Status.IsTerminal() {
+		t.Errorf("expected failed status to be terminal")
+	}
+}
+
+// TestGetOperationJobStatus_EmptyJobID verifies the guard against an
+// empty job_id that would otherwise produce a malformed URL.
+func TestGetOperationJobStatus_EmptyJobID(t *testing.T) {
+	c := connectorsclient.NewClient("http://example", "tok", "en")
+	_, err := c.GetOperationJobStatus(context.Background(), "")
+	if err == nil {
+		t.Fatalf("expected error for empty jobID")
+	}
+}
+
+// TestFetchOperationResult_HappyPath verifies streaming delivery of
+// the zip body and the caller-owned Close lifecycle.
+func TestFetchOperationResult_HappyPath(t *testing.T) {
+	want := []byte("PK\x03\x04 fake zip bytes for testing purposes")
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasPrefix(r.URL.Path, "/operation/result/") {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/zip")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(want)
+	}))
+	defer srv.Close()
+
+	c := connectorsclient.NewClient(srv.URL, "tok", "en")
+	rc, err := c.FetchOperationResult(context.Background(), "opjob_test123")
+	if err != nil {
+		t.Fatalf("FetchOperationResult: %v", err)
+	}
+	defer func() { _ = rc.Close() }()
+
+	got, err := io.ReadAll(rc)
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	if string(got) != string(want) {
+		t.Errorf("body mismatch: got %d bytes, want %d", len(got), len(want))
+	}
+}
+
+// TestFetchOperationResult_NotReady verifies the 409 → ErrResultNotReady
+// mapping, so Core's poll loop can tell the difference between "not yet"
+// and "broken" without inspecting the response body.
+func TestFetchOperationResult_NotReady(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusConflict)
+		_, _ = w.Write([]byte(`{"error":"job still running"}`))
+	}))
+	defer srv.Close()
+
+	c := connectorsclient.NewClient(srv.URL, "tok", "en")
+	rc, err := c.FetchOperationResult(context.Background(), "opjob_test123")
+	if rc != nil {
+		_ = rc.Close()
+		t.Fatalf("expected nil reader on not-ready")
+	}
+	if !errors.Is(err, connectorsclient.ErrResultNotReady) {
+		t.Fatalf("err = %v, want ErrResultNotReady", err)
+	}
+}
+
+// TestFetchOperationResult_ServerError verifies that a 500 surfaces
+// as *APIError (not ErrResultNotReady) so diagnostic bodies surface.
+func TestFetchOperationResult_ServerError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte("broken"))
+	}))
+	defer srv.Close()
+
+	c := connectorsclient.NewClient(srv.URL, "tok", "en")
+	rc, err := c.FetchOperationResult(context.Background(), "opjob_test123")
+	if rc != nil {
+		_ = rc.Close()
+		t.Fatalf("expected nil reader on server error")
+	}
+	var apiErr *connectorsclient.APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("err = %v, want *APIError", err)
+	}
+	if apiErr.StatusCode != http.StatusInternalServerError {
+		t.Errorf("StatusCode = %d, want 500", apiErr.StatusCode)
+	}
+}
+
+// TestCancelOperationJob_HappyPath verifies a 204 (or 200) is
+// treated as success and that the path is built correctly.
+func TestCancelOperationJob_HappyPath(t *testing.T) {
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		if r.Method != http.MethodPost {
+			t.Errorf("method = %s, want POST", r.Method)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	c := connectorsclient.NewClient(srv.URL, "tok", "en")
+	if err := c.CancelOperationJob(context.Background(), "opjob_test123"); err != nil {
+		t.Fatalf("CancelOperationJob: %v", err)
+	}
+	if gotPath != "/operation/cancel/opjob_test123" {
+		t.Errorf("path = %q, want /operation/cancel/opjob_test123", gotPath)
+	}
+}
+
+// TestJobFailedError_Unwrap verifies errors.Is / errors.As work as
+// documented for callers that want to distinguish cancelled from
+// failed after wrapping.
+func TestJobFailedError_Unwrap(t *testing.T) {
+	err := &connectorsclient.JobFailedError{
+		Status:  irminmodels.OperationJobStatusFailed,
+		Message: "boom",
+	}
+	if !errors.Is(err, connectorsclient.ErrJobFailed) {
+		t.Errorf("errors.Is(err, ErrJobFailed) = false, want true")
+	}
+	var target *connectorsclient.JobFailedError
+	if !errors.As(err, &target) {
+		t.Fatalf("errors.As failed")
+	}
+	if target.Status != irminmodels.OperationJobStatusFailed {
+		t.Errorf("target.Status = %q, want failed", target.Status)
+	}
+	if target.Message != "boom" {
+		t.Errorf("target.Message = %q, want boom", target.Message)
+	}
+}

--- a/docs/docs.md
+++ b/docs/docs.md
@@ -7448,7 +7448,10 @@ type ProgressEvent struct {
     // starting_after), or "" for the first page.
     Cursor string `json:"cursor,omitempty"`
 
-    // Attempt is the 0-based retry attempt.
+    // Attempt is the 1-based retry attempt (1 = first retry, 2 = second, …).
+    // 1-based so that omitempty can elide the field on non-rate-limit
+    // events without colliding with a meaningful "first retry" value —
+    // matching the Page and Batch conventions.
     Attempt int `json:"attempt,omitempty"`
     // Wait is how long the caller is about to sleep before retrying.
     // Serialised as a Go duration (nanoseconds) so the round trip is

--- a/docs/docs.md
+++ b/docs/docs.md
@@ -3687,6 +3687,268 @@ type WorkflowRequest struct {
 }
 ```
 
+# connectorsclient
+
+```go
+import "github.com/IrminData/irmin-sdk-go/connectorsclient"
+```
+
+Package connectorsclient is the Irmin SDK client for the connector\-service HTTP plugin protocol.
+
+At present the package intentionally covers only the asynchronous pull protocol — POST /operation/pull \(202 \+ job\_id\), GET /operation/status/:job\_id, GET /operation/result/:job\_id, and POST /operation/cancel/:job\_id — because that is the surface Core needs to stop buffering large zips in memory and avoid Railway's \~300s edge timeout on long Stripe / Pinecone / Postgres pulls.
+
+Core today has an in\-repo connectors\-client with the full set of synchronous endpoints \(init, pull, push, patch, subscribe, etc.\). Migration plan:
+
+1. SDK publishes these async types \+ methods \(this package\).
+2. Core's in\-repo client switches to depend on these for the async endpoints, keeping the existing sync helpers for everything else.
+3. Remaining helpers move into this SDK package incrementally.
+
+Consumers that only need the async protocol \(tests, tooling\) can use this package standalone. It carries no transitive dependency on Core or the connectors service beyond the shared SDK models.
+
+## Index
+
+- [Constants](<#constants>)
+- [Variables](<#variables>)
+- [type APIError](<#APIError>)
+  - [func \(e \*APIError\) Error\(\) string](<#APIError.Error>)
+- [type Client](<#Client>)
+  - [func NewClient\(baseURL, token, locale string\) \*Client](<#NewClient>)
+  - [func \(c \*Client\) CancelOperationJob\(ctx context.Context, jobID string\) error](<#Client.CancelOperationJob>)
+  - [func \(c \*Client\) FetchOperationResult\(ctx context.Context, jobID string\) \(io.ReadCloser, error\)](<#Client.FetchOperationResult>)
+  - [func \(c \*Client\) GetOperationJobStatus\(ctx context.Context, jobID string\) \(\*irminmodels.OperationJobStatusResponse, error\)](<#Client.GetOperationJobStatus>)
+  - [func \(c \*Client\) StartOperationPull\(ctx context.Context, req StartOperationPullRequest\) \(\*irminmodels.StartOperationPullResponse, error\)](<#Client.StartOperationPull>)
+  - [func \(c \*Client\) WithConnectionID\(id uint\) \*Client](<#Client.WithConnectionID>)
+- [type JobFailedError](<#JobFailedError>)
+  - [func \(e \*JobFailedError\) Error\(\) string](<#JobFailedError.Error>)
+  - [func \(e \*JobFailedError\) Unwrap\(\) error](<#JobFailedError.Unwrap>)
+- [type StartOperationPullRequest](<#StartOperationPullRequest>)
+
+
+## Constants
+
+<a name="HeaderConnectionID"></a>HeaderConnectionID is sent on every outbound connector request so the receiving service can identify which Irmin Connection the operation belongs to. The value mirrors the exact string used by the existing Core\-side connectors\-client so migration is a drop\-in.
+
+Using Go's canonical HTTP header form avoids net/http silently rewriting it at send time and keeps reads consistent.
+
+```go
+const HeaderConnectionID = "X-Irmin-Connection-Id"
+```
+
+## Variables
+
+<a name="ErrJobFailed"></a>ErrJobFailed is returned when a status response indicates the job has reached a non\-success terminal state \(failed or cancelled\). Callers that wrap this can surface the original connector\-supplied error message from OperationJobStatusResponse.Error.
+
+```go
+var ErrJobFailed = errors.New("operation job ended in a non-success terminal state")
+```
+
+<a name="ErrLegacySyncPullResponse"></a>ErrLegacySyncPullResponse is returned by StartOperationPull when the connector service responds with a 200 OK \+ zip body instead of the expected 202 Accepted \+ \{job\_id\}. Its presence means the connector service is still on the pre\-async protocol and the caller is talking to an unmigrated deployment; the Core poll wrapper should bail out with an actionable message rather than attempt a silent fallback, per the "no backward\-compat shim" decision in the async\-pull plan.
+
+```go
+var ErrLegacySyncPullResponse = errors.New(
+    "connector returned legacy synchronous pull response (HTTP 200 with body); " +
+        "expected 202 Accepted from async protocol — upgrade the connector service",
+)
+```
+
+<a name="ErrResultNotReady"></a>ErrResultNotReady is returned by FetchOperationResult when the job is still in a non\-terminal state \(pending or running\) at the time of the fetch. The Core poll wrapper should only call FetchOperationResult after observing status=complete; this error surfaces a protocol mistake rather than a transient condition and is not safe to retry without polling status again.
+
+```go
+var ErrResultNotReady = errors.New(
+    "operation result is not ready: job has not reached terminal status=complete",
+)
+```
+
+<a name="APIError"></a>
+## type APIError
+
+APIError is returned when the connector service responds with an unexpected HTTP status code. Callers can inspect StatusCode and Body for diagnostics, or use errors.As to unwrap it from wrapped errors.
+
+```go
+type APIError struct {
+    // StatusCode is the HTTP status returned by the connector.
+    StatusCode int
+    // Body is the response body (may be JSON, may be plain text)
+    // captured verbatim for diagnostics.
+    Body string
+}
+```
+
+<a name="APIError.Error"></a>
+### func \(\*APIError\) Error
+
+```go
+func (e *APIError) Error() string
+```
+
+Error implements the error interface.
+
+<a name="Client"></a>
+## type Client
+
+Client is the async\-protocol connector\-service HTTP client.
+
+A Client is safe for concurrent use. It keeps two underlying http.Clients: one for short request/response calls \(status, start, cancel\) and one without a top\-level timeout for the streaming result fetch, so long zip downloads are not cut off by the request\-response timer.
+
+```go
+type Client struct {
+    // BaseURL is the connector service base, e.g.
+    // "https://connectors.irmin.dev/stripe". It must include the
+    // connector-specific prefix the service expects.
+    BaseURL string
+
+    // Token is the operation or system token for the connector,
+    // set on the Authorization header as "Bearer <token>".
+    Token string
+
+    // Locale is used to request localised messages from the
+    // connector service via the Accept-Language header.
+    Locale string
+
+    // HTTPClient is the client used for short requests (start,
+    // status, cancel). Defaults to a client with
+    // irminsdkgo.DefaultConnectorTimeout. Callers that need custom
+    // transports, proxies, or timeouts may replace it.
+    HTTPClient *http.Client
+
+    // ConnectionID is the Irmin Connection ID this client is
+    // operating on behalf of. When non-zero it is sent as
+    // HeaderConnectionID on every outbound request so OAuth-backed
+    // connectors can fetch the right access token. Leave zero for
+    // calls that are not connection-scoped.
+    ConnectionID uint
+    // contains filtered or unexported fields
+}
+```
+
+<a name="NewClient"></a>
+### func NewClient
+
+```go
+func NewClient(baseURL, token, locale string) *Client
+```
+
+NewClient creates a new connector\-service client with sensible default http.Client settings. The two underlying clients share a single transport so connection pooling and TLS sessions are reused across short and streaming calls.
+
+<a name="Client.CancelOperationJob"></a>
+### func \(\*Client\) CancelOperationJob
+
+```go
+func (c *Client) CancelOperationJob(ctx context.Context, jobID string) error
+```
+
+CancelOperationJob requests that the connector service cancel an in\-flight async operation job. Safe to call on terminal jobs \(server is expected to treat it as a no\-op\). Uses POST with the job\_id on the path so it composes with existing per\-job routes.
+
+<a name="Client.FetchOperationResult"></a>
+### func \(\*Client\) FetchOperationResult
+
+```go
+func (c *Client) FetchOperationResult(ctx context.Context, jobID string) (io.ReadCloser, error)
+```
+
+FetchOperationResult streams the result archive \(zip\) for a completed async operation job. The caller is responsible for closing the returned io.ReadCloser — the connection stays open until the caller drains or closes it, and the request context governs the transfer lifetime.
+
+The body is intentionally not buffered into memory; this is the whole point of the async protocol. Callers should pipe the reader directly into their downstream processing \(archive extraction, re\-upload to LakeFS, etc.\) so the zip never lands fully on either peer.
+
+Semantics by response status:
+
+- 200 OK with application/zip \(or any non\-JSON\) body: returns the body reader.
+- 409 Conflict: the job is not yet in terminal state complete. Returns ErrResultNotReady; callers should resume polling status rather than retry the result fetch.
+- Any other non\-2xx: returns \*APIError.
+
+<a name="Client.GetOperationJobStatus"></a>
+### func \(\*Client\) GetOperationJobStatus
+
+```go
+func (c *Client) GetOperationJobStatus(ctx context.Context, jobID string) (*irminmodels.OperationJobStatusResponse, error)
+```
+
+GetOperationJobStatus polls the status of an async operation job. Safe to call repeatedly; the Core side drives a poll loop at roughly 5s cadence. Progress events on the response are cumulative, so consumers may either diff against a previously seen slice or replace their local view wholesale.
+
+The caller should stop polling once the returned Status satisfies OperationJobStatus.IsTerminal.
+
+<a name="Client.StartOperationPull"></a>
+### func \(\*Client\) StartOperationPull
+
+```go
+func (c *Client) StartOperationPull(ctx context.Context, req StartOperationPullRequest) (*irminmodels.StartOperationPullResponse, error)
+```
+
+StartOperationPull initiates an asynchronous pull against a connector. It expects the connector service to respond with 202 Accepted and \{job\_id, ...\}; the returned StartOperationPullResponse carries that job\_id, which the caller then uses to poll status and, eventually, fetch the result.
+
+On HTTP 200 \(legacy synchronous response\) this returns ErrLegacySyncPullResponse without attempting to drain the body — per the async\-pull plan there is intentionally no sync fallback, and surfacing a specific error lets the Core poll wrapper print an actionable message rather than silently degrade.
+
+Any other non\-2xx status returns an \*APIError.
+
+<a name="Client.WithConnectionID"></a>
+### func \(\*Client\) WithConnectionID
+
+```go
+func (c *Client) WithConnectionID(id uint) *Client
+```
+
+WithConnectionID returns the receiver after setting ConnectionID, enabling a fluent call\-site:
+
+```
+client := connectorsclient.NewClient(url, tok, "en").WithConnectionID(conn.ID)
+```
+
+Mutates and returns the same pointer. Passing 0 clears the connection context.
+
+<a name="JobFailedError"></a>
+## type JobFailedError
+
+JobFailedError wraps ErrJobFailed with the terminal status and the connector\-supplied error message, so callers that wish to act on cancelled vs. failed can discriminate without re\-reading the status response.
+
+```go
+type JobFailedError struct {
+    // Status is the terminal status observed. Always
+    // OperationJobStatusFailed or OperationJobStatusCancelled.
+    Status irminmodels.OperationJobStatus
+    // Message is the operator-facing error message from the status
+    // response. May be empty for cancellations.
+    Message string
+}
+```
+
+<a name="JobFailedError.Error"></a>
+### func \(\*JobFailedError\) Error
+
+```go
+func (e *JobFailedError) Error() string
+```
+
+Error implements the error interface.
+
+<a name="JobFailedError.Unwrap"></a>
+### func \(\*JobFailedError\) Unwrap
+
+```go
+func (e *JobFailedError) Unwrap() error
+```
+
+Unwrap lets errors.Is\(err, ErrJobFailed\) succeed on wrapped JobFailedError values, so callers can check the sentinel and then use errors.As to extract the detail.
+
+<a name="StartOperationPullRequest"></a>
+## type StartOperationPullRequest
+
+StartOperationPullRequest holds the payload for POST /operation/pull under the async protocol. It intentionally uses the same x\-www\-form\-urlencoded surface as the pre\-async handler so the server\-side route signature does not churn; only the response shape changes \(202 \+ \{job\_id\} instead of a streamed zip body\).
+
+```go
+type StartOperationPullRequest struct {
+    // Path is the connector-specific resource path being pulled
+    // (e.g., "/v1/customers" for Stripe, a table identifier for
+    // Postgres). Required.
+    Path string
+
+    // Extra carries any additional form fields the specific
+    // connector accepts on its pull endpoint (cursor, filters,
+    // batch hints). Use for connector-specific parameters — the
+    // shared SDK types cannot enumerate every connector's knobs.
+    Extra map[string]string
+}
+```
+
 # duckdb
 
 ```go
@@ -4082,6 +4344,10 @@ import "github.com/IrminData/irmin-sdk-go/models"
 - [type ObjectSchema](<#ObjectSchema>)
 - [type ObjectSchemaDiff](<#ObjectSchemaDiff>)
 - [type ObjectType](<#ObjectType>)
+- [type OperationJob](<#OperationJob>)
+- [type OperationJobStatus](<#OperationJobStatus>)
+  - [func \(s OperationJobStatus\) IsTerminal\(\) bool](<#OperationJobStatus.IsTerminal>)
+- [type OperationJobStatusResponse](<#OperationJobStatusResponse>)
 - [type OutputFormat](<#OutputFormat>)
 - [type Patch](<#Patch>)
 - [type PatchDirection](<#PatchDirection>)
@@ -4130,6 +4396,7 @@ import "github.com/IrminData/irmin-sdk-go/models"
 - [type SearchResponse](<#SearchResponse>)
 - [type SearchResult](<#SearchResult>)
 - [type SelectOption](<#SelectOption>)
+- [type StartOperationPullResponse](<#StartOperationPullResponse>)
 - [type StoredQuery](<#StoredQuery>)
 - [type StoredScript](<#StoredScript>)
 - [type SubscriptionStatus](<#SubscriptionStatus>)
@@ -5375,6 +5642,135 @@ const (
 )
 ```
 
+<a name="OperationJob"></a>
+## type OperationJob
+
+OperationJob is the metadata record for an asynchronous connector operation \(currently: pull; push/patch to follow\).
+
+The connector service creates one of these on POST /operation/pull, returns its ID to the caller, then fills in status/progress as the worker runs. The full job payload is typically only returned inside status responses; POST /operation/pull itself returns the slimmer StartOperationPullResponse to keep the accept\-fast path fast.
+
+```go
+type OperationJob struct {
+    // JobID is the connector-service-issued identifier for this job.
+    // Opaque to clients — used to poll status, fetch result, or
+    // cancel.
+    JobID string `json:"job_id" example:"opjob_9m3x7k2n8q5p"`
+
+    // ConnectorID is the SQID of the connector plugin that owns this
+    // job (e.g., Stripe, Pinecone, Postgres). Present so poll
+    // consumers can disambiguate when the same core process runs
+    // multiple pulls in parallel.
+    ConnectorID string `json:"connector_id" example:"conn_5p8q2n7m9x4k"`
+
+    // OperationID is the connector-side operation token / numeric
+    // identifier this job is executing against. Maps to the
+    // Operation record created via /operation/init.
+    OperationID string `json:"operation_id" example:"42"`
+
+    // Status is the current lifecycle state. See OperationJobStatus.
+    Status OperationJobStatus `json:"status" example:"running"`
+
+    // CreatedAt is the UTC time the job was accepted by the
+    // connector service.
+    CreatedAt time.Time `json:"created_at"`
+
+    // ExpiresAt is when the result, if any, will be garbage-collected
+    // by the connector service's janitor. After this point a
+    // /operation/result call is not guaranteed to succeed even for
+    // jobs that reached status=complete. Zero value means no TTL.
+    ExpiresAt time.Time `json:"expires_at,omitempty"`
+}
+```
+
+<a name="OperationJobStatus"></a>
+## type OperationJobStatus
+
+OperationJobStatus enumerates the lifecycle states of an asynchronous connector operation job \(e.g., a long\-running pull\).
+
+The wire\-format string values are stable across service boundaries: irmin\-connectors emits these values on /operation/status and the Core poll wrapper compares against them directly. Treat a rename here as a breaking change for every consumer at once.
+
+```go
+type OperationJobStatus string
+```
+
+<a name="OperationJobStatusPending"></a>
+
+```go
+const (
+    // OperationJobStatusPending means the job has been accepted but
+    // its worker has not yet started. Short-lived state; most consumers
+    // can fold it into "running" for UX purposes.
+    OperationJobStatusPending OperationJobStatus = "pending"
+
+    // OperationJobStatusRunning means the worker goroutine is actively
+    // producing output (paginating an API, scanning rows, building
+    // the result archive, etc.). Progress events on the status
+    // response correspond to this phase.
+    OperationJobStatusRunning OperationJobStatus = "running"
+
+    // OperationJobStatusComplete means the worker finished
+    // successfully and the result is ready to fetch via
+    // /operation/result/:job_id. Terminal.
+    OperationJobStatusComplete OperationJobStatus = "complete"
+
+    // OperationJobStatusFailed means the worker hit an unrecoverable
+    // error and will not produce a result. The error message is
+    // surfaced on the status response. Terminal.
+    OperationJobStatusFailed OperationJobStatus = "failed"
+
+    // OperationJobStatusCancelled means the job was cancelled before
+    // it could finish, either by an explicit /operation/cancel call
+    // or by the connector service shutting the job down (e.g., TTL
+    // expiry, pod shutdown). Terminal.
+    OperationJobStatusCancelled OperationJobStatus = "cancelled"
+)
+```
+
+<a name="OperationJobStatus.IsTerminal"></a>
+### func \(OperationJobStatus\) IsTerminal
+
+```go
+func (s OperationJobStatus) IsTerminal() bool
+```
+
+IsTerminal reports whether a status is a terminal state \(no further transitions\). Useful for the Core poll loop's exit condition.
+
+<a name="OperationJobStatusResponse"></a>
+## type OperationJobStatusResponse
+
+OperationJobStatusResponse is the body returned by GET /operation/status/:job\_id. It carries the current status plus any observability events accumulated since job start, so the console can surface per\-page / per\-batch / rate\-limit progress without opening a separate stream.
+
+Progress events are cumulative — the connector service appends to the slice as work proceeds. Clients polling every \~5s can diff Progress against what they've already displayed, or simply replace.
+
+```go
+type OperationJobStatusResponse struct {
+    // JobID echoes the ID from the URL so callers receiving a batch
+    // of responses (or logs) can associate the body with its job
+    // without re-parsing the request.
+    JobID string `json:"job_id" example:"opjob_9m3x7k2n8q5p"`
+
+    // Status is the current lifecycle state at the time of the
+    // response. Callers should stop polling once this becomes
+    // terminal (see OperationJobStatus.IsTerminal).
+    Status OperationJobStatus `json:"status" example:"running"`
+
+    // Progress is the cumulative slice of observability events the
+    // connector worker has emitted so far. Uses the shared
+    // observability.ProgressEvent vocabulary, so a "page" or
+    // "rate_limit" event means the same thing here as it does in
+    // Core workflow logs or AI stream events.
+    //
+    // May be empty for short-lived jobs that finish before any
+    // event is emitted.
+    Progress []observability.ProgressEvent `json:"progress,omitempty"`
+
+    // Error is populated when Status is OperationJobStatusFailed.
+    // Operator-facing message; not a machine-readable code. Empty
+    // for any non-failed status.
+    Error string `json:"error,omitempty" example:"stripe API returned 401 Unauthorized"`
+}
+```
+
 <a name="OutputFormat"></a>
 ## type OutputFormat
 
@@ -6370,6 +6766,21 @@ type SelectOption struct {
 }
 ```
 
+<a name="StartOperationPullResponse"></a>
+## type StartOperationPullResponse
+
+StartOperationPullResponse is the body returned by POST /operation/pull under the async protocol. It is intentionally minimal — just the job\_id — so the accept path stays fast and any future fields \(e.g., estimated runtime\) can be added without breaking callers.
+
+The HTTP status for this response is 202 Accepted, not 200 OK, so the Core SDK client uses the status code as the primary protocol discriminator; a legacy 200 with a zip body is reported as ErrLegacySyncPullResponse.
+
+```go
+type StartOperationPullResponse struct {
+    // JobID is the identifier the caller uses on subsequent
+    // /operation/status and /operation/result calls.
+    JobID string `json:"job_id" example:"opjob_9m3x7k2n8q5p"`
+}
+```
+
 <a name="StoredQuery"></a>
 ## type StoredQuery
 
@@ -7013,48 +7424,52 @@ ProgressEvent is a single observability event emitted from a long\-running opera
 
 Not every field is meaningful for every Kind — see the field docs. The Kind discriminator selects which subset applies.
 
+JSON tags are provided so ProgressEvent can round\-trip across the async operation /operation/status wire format. Field names are snake\_case and every per\-kind field is marked omitempty so a "page" event doesn't carry zero\-valued file/rate\-limit fields on the wire. Tag values are part of that wire format and must stay stable across services.
+
 ```go
 type ProgressEvent struct {
     // Kind discriminates the event. Use one of the ProgressKind*
     // constants below.
-    Kind string
+    Kind string `json:"kind"`
 
     // ResourcePath is a human-readable identifier for what's being
     // processed: an API path ("/v1/customers"), a table name
     // ("public.orders"), a file path ("inbox/report.csv"), an
     // index URI ("pinecone://my-index"). Should always be set so
     // operators with multiple targets per workflow can disambiguate.
-    ResourcePath string
+    ResourcePath string `json:"resource_path,omitempty"`
 
     // Page is the 1-based page number within the current pagination
     // loop.
-    Page int
+    Page int `json:"page,omitempty"`
     // RecordsSoFar is the cumulative record count accumulated so far.
-    RecordsSoFar int
+    RecordsSoFar int `json:"records_so_far,omitempty"`
     // Cursor is the cursor value that produced this page (e.g.,
     // starting_after), or "" for the first page.
-    Cursor string
+    Cursor string `json:"cursor,omitempty"`
 
     // Attempt is the 0-based retry attempt.
-    Attempt int
+    Attempt int `json:"attempt,omitempty"`
     // Wait is how long the caller is about to sleep before retrying.
-    Wait time.Duration
+    // Serialised as a Go duration (nanoseconds) so the round trip is
+    // lossless; consumers that prefer seconds can convert.
+    Wait time.Duration `json:"wait,omitempty"`
 
     // Batch is the 1-based batch index.
-    Batch int
+    Batch int `json:"batch,omitempty"`
     // BatchSize is the number of records in this batch.
-    BatchSize int
+    BatchSize int `json:"batch_size,omitempty"`
 
     // Rows is the cumulative number of rows processed.
-    Rows int64
+    Rows int64 `json:"rows,omitempty"`
 
     // File is the file path currently being transferred.
-    File string
+    File string `json:"file,omitempty"`
     // BytesTransferred is the cumulative bytes moved for this
     // operation (or for the current file — emitter decides).
-    BytesTransferred int64
+    BytesTransferred int64 `json:"bytes_transferred,omitempty"`
     // BytesTotal is the total expected bytes, or 0 if unknown.
-    BytesTotal int64
+    BytesTotal int64 `json:"bytes_total,omitempty"`
 }
 ```
 

--- a/docs/docs.md
+++ b/docs/docs.md
@@ -5677,8 +5677,13 @@ type OperationJob struct {
     // ExpiresAt is when the result, if any, will be garbage-collected
     // by the connector service's janitor. After this point a
     // /operation/result call is not guaranteed to succeed even for
-    // jobs that reached status=complete. Zero value means no TTL.
-    ExpiresAt time.Time `json:"expires_at,omitempty"`
+    // jobs that reached status=complete. nil means no TTL.
+    //
+    // Pointer rather than time.Time + omitempty because encoding/json's
+    // omitempty does not treat a zero time.Time as empty — it would
+    // serialise as "0001-01-01T00:00:00Z" on the wire. Matches the
+    // *time.Time convention used elsewhere in this SDK's models.
+    ExpiresAt *time.Time `json:"expires_at,omitempty"`
 }
 ```
 

--- a/docs/html/github_com_IrminData_irmin-sdk-go_connectorsclient.html
+++ b/docs/html/github_com_IrminData_irmin-sdk-go_connectorsclient.html
@@ -1,0 +1,233 @@
+<!doctype html>
+<html><head><meta charset="utf-8"/><title>github.com/IrminData/irmin-sdk-go/connectorsclient</title></head><body>
+<h1>Package github.com/IrminData/irmin-sdk-go/connectorsclient</h1>
+<pre>
+package connectorsclient // import "github.com/IrminData/irmin-sdk-go/connectorsclient"
+
+Package connectorsclient is the Irmin SDK client for the connector-service HTTP
+plugin protocol.
+
+At present the package intentionally covers only the asynchronous pull
+protocol — POST /operation/pull (202 + job_id), GET /operation/status/:job_id,
+GET /operation/result/:job_id, and POST /operation/cancel/:job_id — because
+that is the surface Core needs to stop buffering large zips in memory and avoid
+Railway's ~300s edge timeout on long Stripe / Pinecone / Postgres pulls.
+
+Core today has an in-repo connectors-client with the full set of synchronous
+endpoints (init, pull, push, patch, subscribe, etc.). Migration plan:
+
+ 1. SDK publishes these async types + methods (this package).
+ 2. Core's in-repo client switches to depend on these for the async endpoints,
+    keeping the existing sync helpers for everything else.
+ 3. Remaining helpers move into this SDK package incrementally.
+
+Consumers that only need the async protocol (tests, tooling) can use this
+package standalone. It carries no transitive dependency on Core or the
+connectors service beyond the shared SDK models.
+
+CONSTANTS
+
+const HeaderConnectionID = "X-Irmin-Connection-Id"
+    HeaderConnectionID is sent on every outbound connector request so the
+    receiving service can identify which Irmin Connection the operation belongs
+    to. The value mirrors the exact string used by the existing Core-side
+    connectors-client so migration is a drop-in.
+
+    Using Go's canonical HTTP header form avoids net/http silently rewriting it
+    at send time and keeps reads consistent.
+
+
+VARIABLES
+
+var ErrJobFailed = errors.New("operation job ended in a non-success terminal state")
+    ErrJobFailed is returned when a status response indicates the job has
+    reached a non-success terminal state (failed or cancelled). Callers that
+    wrap this can surface the original connector-supplied error message from
+    OperationJobStatusResponse.Error.
+
+var ErrLegacySyncPullResponse = errors.New(
+	"connector returned legacy synchronous pull response (HTTP 200 with body); " +
+		"expected 202 Accepted from async protocol — upgrade the connector service",
+)
+    ErrLegacySyncPullResponse is returned by StartOperationPull when the
+    connector service responds with a 200 OK + zip body instead of the expected
+    202 Accepted + {job_id}. Its presence means the connector service is still
+    on the pre-async protocol and the caller is talking to an unmigrated
+    deployment; the Core poll wrapper should bail out with an actionable message
+    rather than attempt a silent fallback, per the "no backward-compat shim"
+    decision in the async-pull plan.
+
+var ErrResultNotReady = errors.New(
+	"operation result is not ready: job has not reached terminal status=complete",
+)
+    ErrResultNotReady is returned by FetchOperationResult when the job is still
+    in a non-terminal state (pending or running) at the time of the fetch.
+    The Core poll wrapper should only call FetchOperationResult after observing
+    status=complete; this error surfaces a protocol mistake rather than a
+    transient condition and is not safe to retry without polling status again.
+
+
+TYPES
+
+type APIError struct {
+	// StatusCode is the HTTP status returned by the connector.
+	StatusCode int
+	// Body is the response body (may be JSON, may be plain text)
+	// captured verbatim for diagnostics.
+	Body string
+}
+    APIError is returned when the connector service responds with an unexpected
+    HTTP status code. Callers can inspect StatusCode and Body for diagnostics,
+    or use errors.As to unwrap it from wrapped errors.
+
+func (e *APIError) Error() string
+    Error implements the error interface.
+
+type Client struct {
+	// BaseURL is the connector service base, e.g.
+	// "https://connectors.irmin.dev/stripe". It must include the
+	// connector-specific prefix the service expects.
+	BaseURL string
+
+	// Token is the operation or system token for the connector,
+	// set on the Authorization header as "Bearer &lt;token&gt;".
+	Token string
+
+	// Locale is used to request localised messages from the
+	// connector service via the Accept-Language header.
+	Locale string
+
+	// HTTPClient is the client used for short requests (start,
+	// status, cancel). Defaults to a client with
+	// irminsdkgo.DefaultConnectorTimeout. Callers that need custom
+	// transports, proxies, or timeouts may replace it.
+	HTTPClient *http.Client
+
+	// ConnectionID is the Irmin Connection ID this client is
+	// operating on behalf of. When non-zero it is sent as
+	// HeaderConnectionID on every outbound request so OAuth-backed
+	// connectors can fetch the right access token. Leave zero for
+	// calls that are not connection-scoped.
+	ConnectionID uint
+	// Has unexported fields.
+}
+    Client is the async-protocol connector-service HTTP client.
+
+    A Client is safe for concurrent use. It keeps two underlying http.Clients:
+    one for short request/response calls (status, start, cancel) and one without
+    a top-level timeout for the streaming result fetch, so long zip downloads
+    are not cut off by the request-response timer.
+
+func NewClient(baseURL, token, locale string) *Client
+    NewClient creates a new connector-service client with sensible default
+    http.Client settings. The two underlying clients share a single transport
+    so connection pooling and TLS sessions are reused across short and streaming
+    calls.
+
+func (c *Client) CancelOperationJob(ctx context.Context, jobID string) error
+    CancelOperationJob requests that the connector service cancel an in-flight
+    async operation job. Safe to call on terminal jobs (server is expected to
+    treat it as a no-op). Uses POST with the job_id on the path so it composes
+    with existing per-job routes.
+
+func (c *Client) FetchOperationResult(
+	ctx context.Context,
+	jobID string,
+) (io.ReadCloser, error)
+    FetchOperationResult streams the result archive (zip) for a completed
+    async operation job. The caller is responsible for closing the returned
+    io.ReadCloser — the connection stays open until the caller drains or closes
+    it, and the request context governs the transfer lifetime.
+
+    The body is intentionally not buffered into memory; this is the whole point
+    of the async protocol. Callers should pipe the reader directly into their
+    downstream processing (archive extraction, re-upload to LakeFS, etc.) so the
+    zip never lands fully on either peer.
+
+    Semantics by response status:
+
+      - 200 OK with application/zip (or any non-JSON) body: returns the body
+        reader.
+      - 409 Conflict: the job is not yet in terminal state complete. Returns
+        ErrResultNotReady; callers should resume polling status rather than
+        retry the result fetch.
+      - Any other non-2xx: returns *APIError.
+
+func (c *Client) GetOperationJobStatus(
+	ctx context.Context,
+	jobID string,
+) (*irminmodels.OperationJobStatusResponse, error)
+    GetOperationJobStatus polls the status of an async operation job. Safe to
+    call repeatedly; the Core side drives a poll loop at roughly 5s cadence.
+    Progress events on the response are cumulative, so consumers may either diff
+    against a previously seen slice or replace their local view wholesale.
+
+    The caller should stop polling once the returned Status satisfies
+    OperationJobStatus.IsTerminal.
+
+func (c *Client) StartOperationPull(
+	ctx context.Context,
+	req StartOperationPullRequest,
+) (*irminmodels.StartOperationPullResponse, error)
+    StartOperationPull initiates an asynchronous pull against a connector.
+    It expects the connector service to respond with 202 Accepted and {job_id,
+    ...}; the returned StartOperationPullResponse carries that job_id, which the
+    caller then uses to poll status and, eventually, fetch the result.
+
+    On HTTP 200 (legacy synchronous response) this returns
+    ErrLegacySyncPullResponse without attempting to drain the body — per the
+    async-pull plan there is intentionally no sync fallback, and surfacing a
+    specific error lets the Core poll wrapper print an actionable message rather
+    than silently degrade.
+
+    Any other non-2xx status returns an *APIError.
+
+func (c *Client) WithConnectionID(id uint) *Client
+    WithConnectionID returns the receiver after setting ConnectionID, enabling a
+    fluent call-site:
+
+        client := connectorsclient.NewClient(url, tok, "en").WithConnectionID(conn.ID)
+
+    Mutates and returns the same pointer. Passing 0 clears the connection
+    context.
+
+type JobFailedError struct {
+	// Status is the terminal status observed. Always
+	// OperationJobStatusFailed or OperationJobStatusCancelled.
+	Status irminmodels.OperationJobStatus
+	// Message is the operator-facing error message from the status
+	// response. May be empty for cancellations.
+	Message string
+}
+    JobFailedError wraps ErrJobFailed with the terminal status and the
+    connector-supplied error message, so callers that wish to act on cancelled
+    vs. failed can discriminate without re-reading the status response.
+
+func (e *JobFailedError) Error() string
+    Error implements the error interface.
+
+func (e *JobFailedError) Unwrap() error
+    Unwrap lets errors.Is(err, ErrJobFailed) succeed on wrapped JobFailedError
+    values, so callers can check the sentinel and then use errors.As to extract
+    the detail.
+
+type StartOperationPullRequest struct {
+	// Path is the connector-specific resource path being pulled
+	// (e.g., "/v1/customers" for Stripe, a table identifier for
+	// Postgres). Required.
+	Path string
+
+	// Extra carries any additional form fields the specific
+	// connector accepts on its pull endpoint (cursor, filters,
+	// batch hints). Use for connector-specific parameters — the
+	// shared SDK types cannot enumerate every connector's knobs.
+	Extra map[string]string
+}
+    StartOperationPullRequest holds the payload for POST /operation/pull under
+    the async protocol. It intentionally uses the same x-www-form-urlencoded
+    surface as the pre-async handler so the server-side route signature does not
+    churn; only the response shape changes (202 + {job_id} instead of a streamed
+    zip body).
+
+</pre>
+</body></html>

--- a/docs/html/github_com_IrminData_irmin-sdk-go_models.html
+++ b/docs/html/github_com_IrminData_irmin-sdk-go_models.html
@@ -833,8 +833,13 @@ type OperationJob struct {
 	// ExpiresAt is when the result, if any, will be garbage-collected
 	// by the connector service's janitor. After this point a
 	// /operation/result call is not guaranteed to succeed even for
-	// jobs that reached status=complete. Zero value means no TTL.
-	ExpiresAt time.Time `json:"expires_at,omitempty"`
+	// jobs that reached status=complete. nil means no TTL.
+	//
+	// Pointer rather than time.Time + omitempty because encoding/json's
+	// omitempty does not treat a zero time.Time as empty — it would
+	// serialise as "0001-01-01T00:00:00Z" on the wire. Matches the
+	// *time.Time convention used elsewhere in this SDK's models.
+	ExpiresAt *time.Time `json:"expires_at,omitempty"`
 }
     OperationJob is the metadata record for an asynchronous connector operation
     (currently: pull; push/patch to follow).

--- a/docs/html/github_com_IrminData_irmin-sdk-go_models.html
+++ b/docs/html/github_com_IrminData_irmin-sdk-go_models.html
@@ -806,6 +806,122 @@ const (
 	// ObjectTypeBinary is a binary file, which can't be parsed or queried (e.g. image, video, audio, etc.)
 	ObjectTypeBinary ObjectType = "binary"
 )
+type OperationJob struct {
+	// JobID is the connector-service-issued identifier for this job.
+	// Opaque to clients — used to poll status, fetch result, or
+	// cancel.
+	JobID string `json:"job_id" example:"opjob_9m3x7k2n8q5p"`
+
+	// ConnectorID is the SQID of the connector plugin that owns this
+	// job (e.g., Stripe, Pinecone, Postgres). Present so poll
+	// consumers can disambiguate when the same core process runs
+	// multiple pulls in parallel.
+	ConnectorID string `json:"connector_id" example:"conn_5p8q2n7m9x4k"`
+
+	// OperationID is the connector-side operation token / numeric
+	// identifier this job is executing against. Maps to the
+	// Operation record created via /operation/init.
+	OperationID string `json:"operation_id" example:"42"`
+
+	// Status is the current lifecycle state. See OperationJobStatus.
+	Status OperationJobStatus `json:"status" example:"running"`
+
+	// CreatedAt is the UTC time the job was accepted by the
+	// connector service.
+	CreatedAt time.Time `json:"created_at"`
+
+	// ExpiresAt is when the result, if any, will be garbage-collected
+	// by the connector service's janitor. After this point a
+	// /operation/result call is not guaranteed to succeed even for
+	// jobs that reached status=complete. Zero value means no TTL.
+	ExpiresAt time.Time `json:"expires_at,omitempty"`
+}
+    OperationJob is the metadata record for an asynchronous connector operation
+    (currently: pull; push/patch to follow).
+
+    The connector service creates one of these on POST /operation/pull, returns
+    its ID to the caller, then fills in status/progress as the worker runs.
+    The full job payload is typically only returned inside status responses;
+    POST /operation/pull itself returns the slimmer StartOperationPullResponse
+    to keep the accept-fast path fast.
+
+type OperationJobStatus string
+    OperationJobStatus enumerates the lifecycle states of an asynchronous
+    connector operation job (e.g., a long-running pull).
+
+    The wire-format string values are stable across service boundaries:
+    irmin-connectors emits these values on /operation/status and the Core poll
+    wrapper compares against them directly. Treat a rename here as a breaking
+    change for every consumer at once.
+
+const (
+	// OperationJobStatusPending means the job has been accepted but
+	// its worker has not yet started. Short-lived state; most consumers
+	// can fold it into "running" for UX purposes.
+	OperationJobStatusPending OperationJobStatus = "pending"
+
+	// OperationJobStatusRunning means the worker goroutine is actively
+	// producing output (paginating an API, scanning rows, building
+	// the result archive, etc.). Progress events on the status
+	// response correspond to this phase.
+	OperationJobStatusRunning OperationJobStatus = "running"
+
+	// OperationJobStatusComplete means the worker finished
+	// successfully and the result is ready to fetch via
+	// /operation/result/:job_id. Terminal.
+	OperationJobStatusComplete OperationJobStatus = "complete"
+
+	// OperationJobStatusFailed means the worker hit an unrecoverable
+	// error and will not produce a result. The error message is
+	// surfaced on the status response. Terminal.
+	OperationJobStatusFailed OperationJobStatus = "failed"
+
+	// OperationJobStatusCancelled means the job was cancelled before
+	// it could finish, either by an explicit /operation/cancel call
+	// or by the connector service shutting the job down (e.g., TTL
+	// expiry, pod shutdown). Terminal.
+	OperationJobStatusCancelled OperationJobStatus = "cancelled"
+)
+func (s OperationJobStatus) IsTerminal() bool
+    IsTerminal reports whether a status is a terminal state (no further
+    transitions). Useful for the Core poll loop's exit condition.
+
+type OperationJobStatusResponse struct {
+	// JobID echoes the ID from the URL so callers receiving a batch
+	// of responses (or logs) can associate the body with its job
+	// without re-parsing the request.
+	JobID string `json:"job_id" example:"opjob_9m3x7k2n8q5p"`
+
+	// Status is the current lifecycle state at the time of the
+	// response. Callers should stop polling once this becomes
+	// terminal (see OperationJobStatus.IsTerminal).
+	Status OperationJobStatus `json:"status" example:"running"`
+
+	// Progress is the cumulative slice of observability events the
+	// connector worker has emitted so far. Uses the shared
+	// observability.ProgressEvent vocabulary, so a "page" or
+	// "rate_limit" event means the same thing here as it does in
+	// Core workflow logs or AI stream events.
+	//
+	// May be empty for short-lived jobs that finish before any
+	// event is emitted.
+	Progress []observability.ProgressEvent `json:"progress,omitempty"`
+
+	// Error is populated when Status is OperationJobStatusFailed.
+	// Operator-facing message; not a machine-readable code. Empty
+	// for any non-failed status.
+	Error string `json:"error,omitempty" example:"stripe API returned 401 Unauthorized"`
+}
+    OperationJobStatusResponse is the body returned by GET
+    /operation/status/:job_id. It carries the current status plus any
+    observability events accumulated since job start, so the console can surface
+    per-page / per-batch / rate-limit progress without opening a separate
+    stream.
+
+    Progress events are cumulative — the connector service appends to the slice
+    as work proceeds. Clients polling every ~5s can diff Progress against what
+    they've already displayed, or simply replace.
+
 type OutputFormat string
     OutputFormat represents the output format for format conversion.
 
@@ -1449,6 +1565,20 @@ type SelectOption struct {
 	Value string `json:"value" validate:"required,max=100" example:"Value 1"`
 }
     SelectOption represents an option for select/radio fields.
+
+type StartOperationPullResponse struct {
+	// JobID is the identifier the caller uses on subsequent
+	// /operation/status and /operation/result calls.
+	JobID string `json:"job_id" example:"opjob_9m3x7k2n8q5p"`
+}
+    StartOperationPullResponse is the body returned by POST /operation/pull
+    under the async protocol. It is intentionally minimal — just the job_id — so
+    the accept path stays fast and any future fields (e.g., estimated runtime)
+    can be added without breaking callers.
+
+    The HTTP status for this response is 202 Accepted, not 200 OK, so the Core
+    SDK client uses the status code as the primary protocol discriminator;
+    a legacy 200 with a zip body is reported as ErrLegacySyncPullResponse.
 
 type StoredQuery struct {
 	ID          string    `json:"id"             validate:"required,validsqid=queries" example:"query_1a2b3c4d5e"`

--- a/docs/html/github_com_IrminData_irmin-sdk-go_observability.html
+++ b/docs/html/github_com_IrminData_irmin-sdk-go_observability.html
@@ -61,44 +61,46 @@ TYPES
 type ProgressEvent struct {
 	// Kind discriminates the event. Use one of the ProgressKind*
 	// constants below.
-	Kind string
+	Kind string `json:"kind"`
 
 	// ResourcePath is a human-readable identifier for what's being
 	// processed: an API path ("/v1/customers"), a table name
 	// ("public.orders"), a file path ("inbox/report.csv"), an
 	// index URI ("pinecone://my-index"). Should always be set so
 	// operators with multiple targets per workflow can disambiguate.
-	ResourcePath string
+	ResourcePath string `json:"resource_path,omitempty"`
 
 	// Page is the 1-based page number within the current pagination
 	// loop.
-	Page int
+	Page int `json:"page,omitempty"`
 	// RecordsSoFar is the cumulative record count accumulated so far.
-	RecordsSoFar int
+	RecordsSoFar int `json:"records_so_far,omitempty"`
 	// Cursor is the cursor value that produced this page (e.g.,
 	// starting_after), or "" for the first page.
-	Cursor string
+	Cursor string `json:"cursor,omitempty"`
 
 	// Attempt is the 0-based retry attempt.
-	Attempt int
+	Attempt int `json:"attempt,omitempty"`
 	// Wait is how long the caller is about to sleep before retrying.
-	Wait time.Duration
+	// Serialised as a Go duration (nanoseconds) so the round trip is
+	// lossless; consumers that prefer seconds can convert.
+	Wait time.Duration `json:"wait,omitempty"`
 
 	// Batch is the 1-based batch index.
-	Batch int
+	Batch int `json:"batch,omitempty"`
 	// BatchSize is the number of records in this batch.
-	BatchSize int
+	BatchSize int `json:"batch_size,omitempty"`
 
 	// Rows is the cumulative number of rows processed.
-	Rows int64
+	Rows int64 `json:"rows,omitempty"`
 
 	// File is the file path currently being transferred.
-	File string
+	File string `json:"file,omitempty"`
 	// BytesTransferred is the cumulative bytes moved for this
 	// operation (or for the current file — emitter decides).
-	BytesTransferred int64
+	BytesTransferred int64 `json:"bytes_transferred,omitempty"`
 	// BytesTotal is the total expected bytes, or 0 if unknown.
-	BytesTotal int64
+	BytesTotal int64 `json:"bytes_total,omitempty"`
 }
     ProgressEvent is a single observability event emitted from a long-running
     operation. Producers fire these into a ProgressHandler; the handler is
@@ -107,6 +109,12 @@ type ProgressEvent struct {
 
     Not every field is meaningful for every Kind — see the field docs. The Kind
     discriminator selects which subset applies.
+
+    JSON tags are provided so ProgressEvent can round-trip across the async
+    operation /operation/status wire format. Field names are snake_case and
+    every per-kind field is marked omitempty so a "page" event doesn't carry
+    zero-valued file/rate-limit fields on the wire. Tag values are part of that
+    wire format and must stay stable across services.
 
 type ProgressHandler func(ProgressEvent)
     ProgressHandler receives observability events from long-running operations.

--- a/docs/html/github_com_IrminData_irmin-sdk-go_observability.html
+++ b/docs/html/github_com_IrminData_irmin-sdk-go_observability.html
@@ -79,7 +79,10 @@ type ProgressEvent struct {
 	// starting_after), or "" for the first page.
 	Cursor string `json:"cursor,omitempty"`
 
-	// Attempt is the 0-based retry attempt.
+	// Attempt is the 1-based retry attempt (1 = first retry, 2 = second, …).
+	// 1-based so that omitempty can elide the field on non-rate-limit
+	// events without colliding with a meaningful "first retry" value —
+	// matching the Page and Batch conventions.
 	Attempt int `json:"attempt,omitempty"`
 	// Wait is how long the caller is about to sleep before retrying.
 	// Serialised as a Go duration (nanoseconds) so the round trip is

--- a/docs/html/index.html
+++ b/docs/html/index.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8"/>
 <title>github.com/IrminData/irmin-sdk-go documentation</title>
 <h1>github.com/IrminData/irmin-sdk-go documentation</h1>
-<p>Generated on 2026-04-23 09:22 UTC</p>
+<p>Generated on 2026-04-23 09:32 UTC</p>
 <ul>
 <li><a href="github_com_IrminData_irmin-sdk-go.html">github.com/IrminData/irmin-sdk-go</a></li>
 <li><a href="github_com_IrminData_irmin-sdk-go_api.html">github.com/IrminData/irmin-sdk-go/api</a></li>

--- a/docs/html/index.html
+++ b/docs/html/index.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8"/>
 <title>github.com/IrminData/irmin-sdk-go documentation</title>
 <h1>github.com/IrminData/irmin-sdk-go documentation</h1>
-<p>Generated on 2026-04-23 09:46 UTC</p>
+<p>Generated on 2026-04-23 09:53 UTC</p>
 <ul>
 <li><a href="github_com_IrminData_irmin-sdk-go.html">github.com/IrminData/irmin-sdk-go</a></li>
 <li><a href="github_com_IrminData_irmin-sdk-go_api.html">github.com/IrminData/irmin-sdk-go/api</a></li>

--- a/docs/html/index.html
+++ b/docs/html/index.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8"/>
 <title>github.com/IrminData/irmin-sdk-go documentation</title>
 <h1>github.com/IrminData/irmin-sdk-go documentation</h1>
-<p>Generated on 2026-04-23 09:32 UTC</p>
+<p>Generated on 2026-04-23 09:46 UTC</p>
 <ul>
 <li><a href="github_com_IrminData_irmin-sdk-go.html">github.com/IrminData/irmin-sdk-go</a></li>
 <li><a href="github_com_IrminData_irmin-sdk-go_api.html">github.com/IrminData/irmin-sdk-go/api</a></li>

--- a/docs/html/index.html
+++ b/docs/html/index.html
@@ -2,10 +2,11 @@
 <meta charset="utf-8"/>
 <title>github.com/IrminData/irmin-sdk-go documentation</title>
 <h1>github.com/IrminData/irmin-sdk-go documentation</h1>
-<p>Generated on 2026-04-22 12:32 UTC</p>
+<p>Generated on 2026-04-23 09:22 UTC</p>
 <ul>
 <li><a href="github_com_IrminData_irmin-sdk-go.html">github.com/IrminData/irmin-sdk-go</a></li>
 <li><a href="github_com_IrminData_irmin-sdk-go_api.html">github.com/IrminData/irmin-sdk-go/api</a></li>
+<li><a href="github_com_IrminData_irmin-sdk-go_connectorsclient.html">github.com/IrminData/irmin-sdk-go/connectorsclient</a></li>
 <li><a href="github_com_IrminData_irmin-sdk-go_duckdb.html">github.com/IrminData/irmin-sdk-go/duckdb</a></li>
 <li><a href="github_com_IrminData_irmin-sdk-go_models.html">github.com/IrminData/irmin-sdk-go/models</a></li>
 <li><a href="github_com_IrminData_irmin-sdk-go_observability.html">github.com/IrminData/irmin-sdk-go/observability</a></li>

--- a/docs/html/index.html
+++ b/docs/html/index.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8"/>
 <title>github.com/IrminData/irmin-sdk-go documentation</title>
 <h1>github.com/IrminData/irmin-sdk-go documentation</h1>
-<p>Generated on 2026-04-23 09:53 UTC</p>
+<p>Generated on 2026-04-23 10:00 UTC</p>
 <ul>
 <li><a href="github_com_IrminData_irmin-sdk-go.html">github.com/IrminData/irmin-sdk-go</a></li>
 <li><a href="github_com_IrminData_irmin-sdk-go_api.html">github.com/IrminData/irmin-sdk-go/api</a></li>

--- a/models/operation_job.go
+++ b/models/operation_job.go
@@ -1,0 +1,151 @@
+package irminmodels
+
+import (
+	"time"
+
+	"github.com/IrminData/irmin-sdk-go/observability"
+)
+
+// OperationJobStatus enumerates the lifecycle states of an asynchronous
+// connector operation job (e.g., a long-running pull).
+//
+// The wire-format string values are stable across service boundaries:
+// irmin-connectors emits these values on /operation/status and the
+// Core poll wrapper compares against them directly. Treat a rename
+// here as a breaking change for every consumer at once.
+type OperationJobStatus string
+
+const (
+	// OperationJobStatusPending means the job has been accepted but
+	// its worker has not yet started. Short-lived state; most consumers
+	// can fold it into "running" for UX purposes.
+	OperationJobStatusPending OperationJobStatus = "pending"
+
+	// OperationJobStatusRunning means the worker goroutine is actively
+	// producing output (paginating an API, scanning rows, building
+	// the result archive, etc.). Progress events on the status
+	// response correspond to this phase.
+	OperationJobStatusRunning OperationJobStatus = "running"
+
+	// OperationJobStatusComplete means the worker finished
+	// successfully and the result is ready to fetch via
+	// /operation/result/:job_id. Terminal.
+	OperationJobStatusComplete OperationJobStatus = "complete"
+
+	// OperationJobStatusFailed means the worker hit an unrecoverable
+	// error and will not produce a result. The error message is
+	// surfaced on the status response. Terminal.
+	OperationJobStatusFailed OperationJobStatus = "failed"
+
+	// OperationJobStatusCancelled means the job was cancelled before
+	// it could finish, either by an explicit /operation/cancel call
+	// or by the connector service shutting the job down (e.g., TTL
+	// expiry, pod shutdown). Terminal.
+	OperationJobStatusCancelled OperationJobStatus = "cancelled"
+)
+
+// IsTerminal reports whether a status is a terminal state (no further
+// transitions). Useful for the Core poll loop's exit condition.
+func (s OperationJobStatus) IsTerminal() bool {
+	switch s {
+	case OperationJobStatusComplete,
+		OperationJobStatusFailed,
+		OperationJobStatusCancelled:
+		return true
+	case OperationJobStatusPending, OperationJobStatusRunning:
+		return false
+	default:
+		return false
+	}
+}
+
+// OperationJob is the metadata record for an asynchronous connector
+// operation (currently: pull; push/patch to follow).
+//
+// The connector service creates one of these on POST /operation/pull,
+// returns its ID to the caller, then fills in status/progress as the
+// worker runs. The full job payload is typically only returned inside
+// status responses; POST /operation/pull itself returns the slimmer
+// StartOperationPullResponse to keep the accept-fast path fast.
+type OperationJob struct {
+	// JobID is the connector-service-issued identifier for this job.
+	// Opaque to clients — used to poll status, fetch result, or
+	// cancel.
+	JobID string `json:"job_id" example:"opjob_9m3x7k2n8q5p"`
+
+	// ConnectorID is the SQID of the connector plugin that owns this
+	// job (e.g., Stripe, Pinecone, Postgres). Present so poll
+	// consumers can disambiguate when the same core process runs
+	// multiple pulls in parallel.
+	ConnectorID string `json:"connector_id" example:"conn_5p8q2n7m9x4k"`
+
+	// OperationID is the connector-side operation token / numeric
+	// identifier this job is executing against. Maps to the
+	// Operation record created via /operation/init.
+	OperationID string `json:"operation_id" example:"42"`
+
+	// Status is the current lifecycle state. See OperationJobStatus.
+	Status OperationJobStatus `json:"status" example:"running"`
+
+	// CreatedAt is the UTC time the job was accepted by the
+	// connector service.
+	CreatedAt time.Time `json:"created_at"`
+
+	// ExpiresAt is when the result, if any, will be garbage-collected
+	// by the connector service's janitor. After this point a
+	// /operation/result call is not guaranteed to succeed even for
+	// jobs that reached status=complete. Zero value means no TTL.
+	ExpiresAt time.Time `json:"expires_at,omitempty"`
+}
+
+// OperationJobStatusResponse is the body returned by
+// GET /operation/status/:job_id. It carries the current status plus
+// any observability events accumulated since job start, so the
+// console can surface per-page / per-batch / rate-limit progress
+// without opening a separate stream.
+//
+// Progress events are cumulative — the connector service appends to
+// the slice as work proceeds. Clients polling every ~5s can diff
+// Progress against what they've already displayed, or simply replace.
+type OperationJobStatusResponse struct {
+	// JobID echoes the ID from the URL so callers receiving a batch
+	// of responses (or logs) can associate the body with its job
+	// without re-parsing the request.
+	JobID string `json:"job_id" example:"opjob_9m3x7k2n8q5p"`
+
+	// Status is the current lifecycle state at the time of the
+	// response. Callers should stop polling once this becomes
+	// terminal (see OperationJobStatus.IsTerminal).
+	Status OperationJobStatus `json:"status" example:"running"`
+
+	// Progress is the cumulative slice of observability events the
+	// connector worker has emitted so far. Uses the shared
+	// observability.ProgressEvent vocabulary, so a "page" or
+	// "rate_limit" event means the same thing here as it does in
+	// Core workflow logs or AI stream events.
+	//
+	// May be empty for short-lived jobs that finish before any
+	// event is emitted.
+	Progress []observability.ProgressEvent `json:"progress,omitempty"`
+
+	// Error is populated when Status is OperationJobStatusFailed.
+	// Operator-facing message; not a machine-readable code. Empty
+	// for any non-failed status.
+	Error string `json:"error,omitempty" example:"stripe API returned 401 Unauthorized"`
+}
+
+// StartOperationPullResponse is the body returned by
+// POST /operation/pull under the async protocol. It is intentionally
+// minimal — just the job_id — so the accept path stays fast and any
+// future fields (e.g., estimated runtime) can be added without
+// breaking callers.
+//
+// The HTTP status for this response is 202 Accepted, not 200 OK, so
+// the Core SDK client uses the status code as the primary protocol
+// discriminator; a legacy 200 with a zip body is reported as
+// ErrLegacySyncPullResponse.
+type StartOperationPullResponse struct {
+	// JobID is the identifier the caller uses on subsequent
+	// /operation/status and /operation/result calls.
+	JobID string `json:"job_id" example:"opjob_9m3x7k2n8q5p"`
+}

--- a/models/operation_job.go
+++ b/models/operation_job.go
@@ -94,8 +94,13 @@ type OperationJob struct {
 	// ExpiresAt is when the result, if any, will be garbage-collected
 	// by the connector service's janitor. After this point a
 	// /operation/result call is not guaranteed to succeed even for
-	// jobs that reached status=complete. Zero value means no TTL.
-	ExpiresAt time.Time `json:"expires_at,omitempty"`
+	// jobs that reached status=complete. nil means no TTL.
+	//
+	// Pointer rather than time.Time + omitempty because encoding/json's
+	// omitempty does not treat a zero time.Time as empty — it would
+	// serialise as "0001-01-01T00:00:00Z" on the wire. Matches the
+	// *time.Time convention used elsewhere in this SDK's models.
+	ExpiresAt *time.Time `json:"expires_at,omitempty"`
 }
 
 // OperationJobStatusResponse is the body returned by

--- a/observability/progress.go
+++ b/observability/progress.go
@@ -30,57 +30,66 @@ import "time"
 //
 // Not every field is meaningful for every Kind — see the field docs.
 // The Kind discriminator selects which subset applies.
+//
+// JSON tags are provided so ProgressEvent can round-trip across the
+// async operation /operation/status wire format. Field names are
+// snake_case and every per-kind field is marked omitempty so a
+// "page" event doesn't carry zero-valued file/rate-limit fields on
+// the wire. Tag values are part of that wire format and must stay
+// stable across services.
 type ProgressEvent struct {
 	// Kind discriminates the event. Use one of the ProgressKind*
 	// constants below.
-	Kind string
+	Kind string `json:"kind"`
 
 	// ResourcePath is a human-readable identifier for what's being
 	// processed: an API path ("/v1/customers"), a table name
 	// ("public.orders"), a file path ("inbox/report.csv"), an
 	// index URI ("pinecone://my-index"). Should always be set so
 	// operators with multiple targets per workflow can disambiguate.
-	ResourcePath string
+	ResourcePath string `json:"resource_path,omitempty"`
 
 	// --- Pagination (ProgressKindPage) ---
 
 	// Page is the 1-based page number within the current pagination
 	// loop.
-	Page int
+	Page int `json:"page,omitempty"`
 	// RecordsSoFar is the cumulative record count accumulated so far.
-	RecordsSoFar int
+	RecordsSoFar int `json:"records_so_far,omitempty"`
 	// Cursor is the cursor value that produced this page (e.g.,
 	// starting_after), or "" for the first page.
-	Cursor string
+	Cursor string `json:"cursor,omitempty"`
 
 	// --- Retry / rate-limit (ProgressKindRateLimit) ---
 
 	// Attempt is the 0-based retry attempt.
-	Attempt int
+	Attempt int `json:"attempt,omitempty"`
 	// Wait is how long the caller is about to sleep before retrying.
-	Wait time.Duration
+	// Serialised as a Go duration (nanoseconds) so the round trip is
+	// lossless; consumers that prefer seconds can convert.
+	Wait time.Duration `json:"wait,omitempty"`
 
 	// --- Chunked upload (ProgressKindBatch) ---
 
 	// Batch is the 1-based batch index.
-	Batch int
+	Batch int `json:"batch,omitempty"`
 	// BatchSize is the number of records in this batch.
-	BatchSize int
+	BatchSize int `json:"batch_size,omitempty"`
 
 	// --- SQL query progress (ProgressKindQuery) ---
 
 	// Rows is the cumulative number of rows processed.
-	Rows int64
+	Rows int64 `json:"rows,omitempty"`
 
 	// --- File transfer (ProgressKindFile) ---
 
 	// File is the file path currently being transferred.
-	File string
+	File string `json:"file,omitempty"`
 	// BytesTransferred is the cumulative bytes moved for this
 	// operation (or for the current file — emitter decides).
-	BytesTransferred int64
+	BytesTransferred int64 `json:"bytes_transferred,omitempty"`
 	// BytesTotal is the total expected bytes, or 0 if unknown.
-	BytesTotal int64
+	BytesTotal int64 `json:"bytes_total,omitempty"`
 }
 
 // ProgressKind* enumerate the event types emitted via ProgressHandler.

--- a/observability/progress.go
+++ b/observability/progress.go
@@ -62,7 +62,10 @@ type ProgressEvent struct {
 
 	// --- Retry / rate-limit (ProgressKindRateLimit) ---
 
-	// Attempt is the 0-based retry attempt.
+	// Attempt is the 1-based retry attempt (1 = first retry, 2 = second, …).
+	// 1-based so that omitempty can elide the field on non-rate-limit
+	// events without colliding with a meaningful "first retry" value —
+	// matching the Page and Batch conventions.
 	Attempt int `json:"attempt,omitempty"`
 	// Wait is how long the caller is about to sleep before retrying.
 	// Serialised as a Go duration (nanoseconds) so the round trip is

--- a/observability/progress_test.go
+++ b/observability/progress_test.go
@@ -99,6 +99,7 @@ func TestProgressEvent_JSONWireFormat(t *testing.T) {
 		`"records_so_far":300`,
 		`"cursor":"cus_123"`,
 		`"attempt":1`,
+		`"wait":500000000`,
 		`"batch":2`,
 		`"batch_size":100`,
 		`"rows":10000`,

--- a/observability/progress_test.go
+++ b/observability/progress_test.go
@@ -1,6 +1,8 @@
 package observability_test
 
 import (
+	"encoding/json"
+	"strings"
 	"testing"
 	"time"
 
@@ -61,5 +63,65 @@ func TestProgressEvent_FieldsAccessible(_ *testing.T) {
 		File:             "report.csv",
 		BytesTransferred: 2048,
 		BytesTotal:       4096,
+	}
+}
+
+// TestProgressEvent_JSONWireFormat pins the JSON field names used on
+// the /operation/status wire. These names cross the connectors ↔ Core
+// boundary, so a rename here is a protocol-breaking change that must
+// be caught at SDK build time — before it silently zeroes out
+// progress fields in downstream consumers.
+func TestProgressEvent_JSONWireFormat(t *testing.T) {
+	ev := observability.ProgressEvent{
+		Kind:             observability.ProgressKindFile,
+		ResourcePath:     "/v1/customers",
+		Page:             3,
+		RecordsSoFar:     300,
+		Cursor:           "cus_123",
+		Attempt:          1,
+		Wait:             500 * time.Millisecond,
+		Batch:            2,
+		BatchSize:        100,
+		Rows:             10_000,
+		File:             "report.csv",
+		BytesTransferred: 1024,
+		BytesTotal:       4096,
+	}
+	raw, err := json.Marshal(ev)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	out := string(raw)
+	for _, key := range []string{
+		`"kind":"file"`,
+		`"resource_path":"/v1/customers"`,
+		`"page":3`,
+		`"records_so_far":300`,
+		`"cursor":"cus_123"`,
+		`"attempt":1`,
+		`"batch":2`,
+		`"batch_size":100`,
+		`"rows":10000`,
+		`"file":"report.csv"`,
+		`"bytes_transferred":1024`,
+		`"bytes_total":4096`,
+	} {
+		if !strings.Contains(out, key) {
+			t.Errorf("wire format missing %q in %s", key, out)
+		}
+	}
+
+	// Zero-valued per-kind fields must be omitted so a lean "page"
+	// event doesn't carry file/bytes fields on the wire.
+	minimal := observability.ProgressEvent{Kind: observability.ProgressKindHeartbeat}
+	raw, err = json.Marshal(minimal)
+	if err != nil {
+		t.Fatalf("marshal minimal: %v", err)
+	}
+	out = string(raw)
+	for _, omitted := range []string{"page", "bytes_total", "rate_limit", "file", "rows"} {
+		if strings.Contains(out, omitted) {
+			t.Errorf("minimal event should not carry %q on the wire, got %s", omitted, out)
+		}
 	}
 }


### PR DESCRIPTION
## Summary

Adds the SDK-side surface for an async connector pull protocol (202 Accepted + poll status + fetch result) so long-running pulls survive Railway's ~300s edge timeout. Connectors-service and core will consume these in follow-up PRs.

- New `connectorsclient` package with `StartOperationPull`, `GetOperationJobStatus`, `FetchOperationResult`, `CancelOperationJob` client methods
- New models: `OperationJob`, `OperationJobStatus` (enum: pending/running/complete/failed/cancelled, with `IsTerminal()`), `OperationJobStatusResponse`, `StartOperationPullResponse`
- Typed errors: `ErrLegacySyncPullResponse` (surfaces unmigrated connectors), `ErrResultNotReady` (409 from result endpoint), `JobFailedError` (unwraps to `ErrJobFailed`)
- `observability.ProgressEvent` gains snake_case JSON wire tags so it can cross service boundaries cleanly

## Wire contract (pinned by this PR)

- `POST /operation/pull` → `202 Accepted` + `{"job_id":"..."}` (200 treated as legacy-unmigrated error)
- `GET /operation/status/:job_id` → JSON `OperationJobStatusResponse`; `progress[]` is cumulative
- `GET /operation/result/:job_id` → streams `application/zip` on complete; `409 Conflict` when not ready; `410 Gone` when result file is gone
- `POST /operation/cancel/:job_id` → 2xx; fire-and-forget (cancellation is observed by polling status)

`FetchOperationResult` returns a streaming `io.ReadCloser` — the body is deliberately not buffered so Railway's edge timeout can't bite it.

## Design notes

- `OperationJobStatus` / `OperationJob*` names deliberately avoid collision with Core's existing `OperationStatus` (log-snapshot shape), so Core can adopt these types alongside without a rename.
- No sync fallback. `StartOperationPull` on an unmigrated connector surfaces `ErrLegacySyncPullResponse` with an actionable message rather than silently buffering the zip into memory.
- Cancel is URL-path based (`/operation/cancel/:job_id`) rather than form-body — composes with the other job-scoped routes and keeps the endpoint stateless.

## Test plan

- [ ] Review: the wire format and error sentinels are treated as the protocol contract — downstream PRs in `irmin-connectors` and `irmin` mirror these exactly
- [ ] `go test -race -count=1 ./...` — 12 new tests in `connectorsclient` + 1 in `observability` + pre-existing suites, all passing
- [ ] `golangci-lint run ./...` — 0 issues
- [ ] After merge: tag a release so `irmin-connectors` and `irmin` can pin against it (they currently carry dev-only `replace` directives pointing at this branch's worktree)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new async connector-pull HTTP client surface and wire-format models, plus changes `observability.ProgressEvent` JSON encoding (including `Attempt` semantics) that could impact any consumers relying on the previous struct layout/JSON shape.
> 
> **Overview**
> Adds a new `connectorsclient` package implementing the async pull protocol: `StartOperationPull` (expects `202` + `job_id` and errors on legacy `200`), `GetOperationJobStatus` polling, `FetchOperationResult` streaming zip downloads without buffering, and `CancelOperationJob`.
> 
> Introduces new SDK models for async jobs (`OperationJob`, `OperationJobStatus` + `IsTerminal()`, `OperationJobStatusResponse`, `StartOperationPullResponse`) and typed error handling (`APIError`, `ErrLegacySyncPullResponse`, `ErrResultNotReady`, `ErrJobFailed`/`JobFailedError`).
> 
> Updates `observability.ProgressEvent` with snake_case JSON tags and omitempty fields to make progress events round-trip over `/operation/status`, and extends tests/docs to pin the new wire contract.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4694c589e3ac886f873992f4d0e77ca508917fd0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->