### PR TITLE
feat(connectorsclient): structured error envelopes for async ops

### DIFF
--- a/connectorsclient/errors.go
+++ b/connectorsclient/errors.go
@@ -84,3 +84,94 @@ func (e *JobFailedError) Error() string {
 func (e *JobFailedError) Unwrap() error {
 	return ErrJobFailed
 }
+
+// ErrOperationAlreadyRunning is the sentinel returned when a
+// connector refuses a request because the same operation is already
+// in flight (HTTP 409). Callers wrap this with AlreadyRunningError
+// to surface the job_id of the blocker; use errors.As to unwrap.
+var ErrOperationAlreadyRunning = errors.New(
+	"connector refused the request: operation is already running",
+)
+
+// AlreadyRunningError wraps ErrOperationAlreadyRunning with the
+// details of the currently-running job so callers can redirect their
+// polling (or issue a cancel) without a second round-trip to the
+// server to discover what's holding the lock.
+//
+// Returned by StartOperationPull (and any other op-start path that
+// migrates onto the async protocol) when the server responds with
+// HTTP 409 + an AlreadyRunningBody payload.
+type AlreadyRunningError struct {
+	// Body is the full structured payload the server returned. JobID
+	// is the most useful field for callers, but Kind / StartedAt /
+	// OperationID are kept for logs and operator diagnostics.
+	Body irminmodels.AlreadyRunningBody
+}
+
+// Error implements the error interface.
+func (e *AlreadyRunningError) Error() string {
+	if e.Body.JobID == "" {
+		// Legacy holder without a registered job row. Callers
+		// shouldn't try to cancel by job_id; the retry-later hint is
+		// the best we can give.
+		return "operation is already running (no job_id available; retry later)"
+	}
+	return fmt.Sprintf(
+		"operation is already running (job_id=%s, kind=%s)",
+		e.Body.JobID, e.Body.Kind,
+	)
+}
+
+// Unwrap lets errors.Is(err, ErrOperationAlreadyRunning) succeed on
+// wrapped AlreadyRunningError values, matching the pattern used by
+// JobFailedError.
+func (e *AlreadyRunningError) Unwrap() error {
+	return ErrOperationAlreadyRunning
+}
+
+// JobID is a convenience accessor for the most commonly consumed
+// field so callers don't have to reach through Body every time.
+func (e *AlreadyRunningError) JobID() string {
+	return e.Body.JobID
+}
+
+// JobServerError wraps a structured JobErrorBody returned by the
+// async-job endpoints (status/result/cancel) on any non-2xx
+// response. Callers driving retry logic should inspect Retryable
+// and Reason rather than the raw Error string.
+//
+// Returned by GetOperationJobStatus, FetchOperationResult, and
+// CancelOperationJob when the server responds with a structured
+// JobErrorBody payload. For older servers that still return the
+// unstructured {"error": "..."} shape, the client falls back to
+// APIError so this type only surfaces on migrated deployments.
+type JobServerError struct {
+	// StatusCode is the HTTP status returned by the connector. Kept
+	// separately from Body so callers can discriminate 404 vs 500
+	// without re-parsing the reason code.
+	StatusCode int
+
+	// Body is the structured error envelope. Reason and Retryable
+	// are the machine-readable signals; Error carries the
+	// operator-facing message.
+	Body irminmodels.JobErrorBody
+}
+
+// Error implements the error interface.
+func (e *JobServerError) Error() string {
+	return fmt.Sprintf(
+		"connector job endpoint returned status %d (reason=%s, retryable=%t): %s",
+		e.StatusCode, e.Body.Reason, e.Body.Retryable, e.Body.Error,
+	)
+}
+
+// Retryable reports whether the server classified this failure as
+// safe to retry after a short backoff.
+func (e *JobServerError) Retryable() bool {
+	return e.Body.Retryable
+}
+
+// Reason returns the machine-readable failure classification.
+func (e *JobServerError) Reason() irminmodels.JobErrorReason {
+	return e.Body.Reason
+}

--- a/connectorsclient/operation_async.go
+++ b/connectorsclient/operation_async.go
@@ -78,6 +78,19 @@ func (c *Client) StartOperationPull(
 		return nil, ErrLegacySyncPullResponse
 	}
 
+	// 409 Conflict is the structured "operation already running"
+	// signal. Parse the body into AlreadyRunningError so callers can
+	// errors.As it and reach the blocking job_id directly. If the
+	// body does not match the structured shape, fall back to
+	// *APIError to preserve diagnostics for pre-envelope servers.
+	if resp.StatusCode == http.StatusConflict {
+		bodyBytes := readBoundedBody(resp)
+		if alreadyErr := readAlreadyRunningError(bodyBytes); alreadyErr != nil {
+			return nil, alreadyErr
+		}
+		return nil, apiErrorFromBytes(resp.StatusCode, bodyBytes)
+	}
+
 	if resp.StatusCode != http.StatusAccepted {
 		return nil, readAPIError(resp)
 	}
@@ -129,7 +142,7 @@ func (c *Client) GetOperationJobStatus(
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, readAPIError(resp)
+		return nil, readJobNonSuccess(resp)
 	}
 
 	bodyBytes, err := io.ReadAll(resp.Body)
@@ -189,6 +202,12 @@ func (c *Client) FetchOperationResult(
 	// Bounded drain — streamClient has no top-level timeout, so a
 	// misbehaving server sending an unbounded 409 body would otherwise
 	// hang this path. errorBodyReadLimit matches readAPIError's guard.
+	//
+	// We keep ErrResultNotReady as the primary signal here because
+	// the poll wrapper's state machine keys off it; the structured
+	// JobErrorBody shape does not override that semantic — a 409 on
+	// the result endpoint means "keep polling status" regardless of
+	// whether the body carries a reason.
 	if resp.StatusCode == http.StatusConflict {
 		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, errorBodyReadLimit))
 		_ = resp.Body.Close()
@@ -196,7 +215,7 @@ func (c *Client) FetchOperationResult(
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		apiErr := readAPIError(resp)
+		apiErr := readJobNonSuccess(resp)
 		_ = resp.Body.Close()
 		return nil, apiErr
 	}
@@ -209,30 +228,69 @@ func (c *Client) FetchOperationResult(
 // in-flight async operation job. Safe to call on terminal jobs
 // (server is expected to treat it as a no-op). Uses POST with the
 // job_id on the path so it composes with existing per-job routes.
+//
+// Returns nil on any 2xx; the richer response shape (status,
+// was_active) is available via CancelOperationJobDetail. Callers
+// that only need idempotent fire-and-forget semantics can keep
+// calling this method.
 func (c *Client) CancelOperationJob(ctx context.Context, jobID string) error {
+	_, err := c.CancelOperationJobDetail(ctx, jobID)
+	return err
+}
+
+// CancelOperationJobDetail is the richer form of CancelOperationJob
+// that returns the parsed CancelOperationJobResponse on success so
+// callers can tell "we actually signalled a running worker"
+// (WasActive=true) from "job was already terminal" (WasActive=false).
+//
+// Servers that pre-date the structured response shape will return a
+// 200 without WasActive; in that case the response carries the
+// default zero values (Status="", WasActive=false) and callers
+// should treat that as the legacy "accepted, unknown state" signal.
+func (c *Client) CancelOperationJobDetail(
+	ctx context.Context,
+	jobID string,
+) (*irminmodels.CancelOperationJobResponse, error) {
 	if jobID == "" {
-		return errors.New("jobID must not be empty")
+		return nil, errors.New("jobID must not be empty")
 	}
 
 	endpoint := fmt.Sprintf("%s/operation/cancel/%s", c.BaseURL, url.PathEscape(jobID))
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, nil)
 	if err != nil {
-		return fmt.Errorf("failed to build cancel request: %w", err)
+		return nil, fmt.Errorf("failed to build cancel request: %w", err)
 	}
 	c.applyDefaultHeaders(httpReq, "application/json")
 
 	resp, err := c.HTTPClient.Do(httpReq)
 	if err != nil {
-		return fmt.Errorf("cancel request to %s failed: %w", httpReq.URL, err)
+		return nil, fmt.Errorf("cancel request to %s failed: %w", httpReq.URL, err)
 	}
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return readAPIError(resp)
+		return nil, readJobNonSuccess(resp)
 	}
-	// Response body (if any) is ignored — cancel is fire-and-forget.
-	_, _ = io.Copy(io.Discard, resp.Body)
-	return nil
+
+	bodyBytes, readErr := io.ReadAll(io.LimitReader(resp.Body, errorBodyReadLimit))
+	if readErr != nil {
+		// Read failure on a 2xx is unexpected — surface it rather
+		// than silently returning a zero-valued response.
+		return nil, fmt.Errorf("failed to read cancel response body: %w", readErr)
+	}
+	// Legacy servers return {"message": "cancellation requested"}
+	// without the richer fields. Attempt structured decode; if the
+	// body is empty or minimally-shaped the zero-valued response is
+	// the correct thing to return.
+	var out irminmodels.CancelOperationJobResponse
+	if len(bodyBytes) > 0 {
+		// Best-effort decode. JSON errors here would mean the server
+		// returned non-JSON on a 2xx, which contradicts its own
+		// content type; don't fail the cancel over it — the cancel
+		// itself succeeded at the HTTP layer.
+		_ = json.Unmarshal(bodyBytes, &out)
+	}
+	return &out, nil
 }
 
 // encodeStartPullForm renders a StartOperationPullRequest as
@@ -275,4 +333,87 @@ func readAPIError(resp *http.Response) error {
 		StatusCode: resp.StatusCode,
 		Body:       buf.String(),
 	}
+}
+
+// readAlreadyRunningError reads the response body and attempts to
+// decode it into an AlreadyRunningBody. Returns a wrapped
+// *AlreadyRunningError on success, or nil if the body cannot be
+// decoded into the structured shape — the caller should fall back
+// to *APIError (constructed from the same bytes via apiErrorFromBytes)
+// in that case to preserve diagnostics for pre-envelope servers.
+//
+// "Structured shape" means the body was valid JSON containing the
+// canonical Error string. JobID absent is acceptable (legacy sync
+// holder); body totally malformed is not.
+func readAlreadyRunningError(bodyBytes []byte) *AlreadyRunningError {
+	if len(bodyBytes) == 0 {
+		return nil
+	}
+	var body irminmodels.AlreadyRunningBody
+	if err := json.Unmarshal(bodyBytes, &body); err != nil {
+		// Intentional discard — a JSON parse failure means the
+		// server did not send a structured body; the caller falls
+		// back to *APIError with the raw bytes. Propagating the
+		// parse error would obscure the actual HTTP failure.
+		return nil //nolint:nilerr // parse failure means "not structured" — caller falls back to *APIError
+	}
+	if body.Error == "" {
+		// Likely a non-AlreadyRunningBody JSON object (e.g.,
+		// {"foo":"bar"}). Don't claim it's a structured 409.
+		return nil
+	}
+	return &AlreadyRunningError{Body: body}
+}
+
+// readJobServerError attempts to decode bodyBytes into a
+// JobErrorBody. Returns *JobServerError on success, nil otherwise.
+//
+// The discriminator is a non-empty Reason field. Old-style
+// {"error": "..."} bodies lack this and fall through so the caller
+// can surface *APIError with the original bytes.
+func readJobServerError(statusCode int, bodyBytes []byte) *JobServerError {
+	if len(bodyBytes) == 0 {
+		return nil
+	}
+	var body irminmodels.JobErrorBody
+	if err := json.Unmarshal(bodyBytes, &body); err != nil {
+		// Intentional discard — same rationale as
+		// readAlreadyRunningError. A parse failure means the server
+		// did not send a structured body; let the caller fall back
+		// to *APIError with the raw bytes.
+		return nil //nolint:nilerr // parse failure means "not structured" — caller falls back to *APIError
+	}
+	if body.Reason == "" {
+		return nil
+	}
+	return &JobServerError{StatusCode: statusCode, Body: body}
+}
+
+// apiErrorFromBytes is the *APIError fallback for the cases where
+// the structured-body decoders rejected the response. Keeps the raw
+// bytes as the diagnostic Body string so operator-facing logs still
+// see whatever the server actually sent.
+func apiErrorFromBytes(statusCode int, bodyBytes []byte) error {
+	return &APIError{StatusCode: statusCode, Body: string(bodyBytes)}
+}
+
+// readBoundedBody drains up to errorBodyReadLimit bytes of the
+// response body for error-parsing purposes. Separate helper so the
+// structured/legacy decoders operate on the same byte slice without
+// each re-reading resp.Body.
+func readBoundedBody(resp *http.Response) []byte {
+	buf, _ := io.ReadAll(io.LimitReader(resp.Body, errorBodyReadLimit))
+	return buf
+}
+
+// readJobNonSuccess centralises the non-2xx body parsing used by
+// status / result / cancel: prefer *JobServerError when the body
+// carries a structured reason, fall back to *APIError otherwise.
+// Consumes the body.
+func readJobNonSuccess(resp *http.Response) error {
+	bodyBytes := readBoundedBody(resp)
+	if structured := readJobServerError(resp.StatusCode, bodyBytes); structured != nil {
+		return structured
+	}
+	return apiErrorFromBytes(resp.StatusCode, bodyBytes)
 }

--- a/connectorsclient/operation_errors_test.go
+++ b/connectorsclient/operation_errors_test.go
@@ -1,0 +1,389 @@
+package connectorsclient_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/IrminData/irmin-sdk-go/connectorsclient"
+	irminmodels "github.com/IrminData/irmin-sdk-go/models"
+)
+
+// TestStartOperationPull_AlreadyRunning_Structured verifies that a
+// 409 response carrying an AlreadyRunningBody unwraps into
+// *AlreadyRunningError so callers can reach the blocking job_id
+// without re-parsing the body.
+func TestStartOperationPull_AlreadyRunning_Structured(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusConflict)
+		_ = json.NewEncoder(w).Encode(irminmodels.AlreadyRunningBody{
+			Error:       "Operation is already running",
+			JobID:       "opjob_blocker123",
+			OperationID: 42,
+			Kind:        "pull",
+		})
+	}))
+	defer srv.Close()
+
+	c := connectorsclient.NewClient(srv.URL, "tok", "en")
+	_, err := c.StartOperationPull(
+		context.Background(),
+		connectorsclient.StartOperationPullRequest{Path: "/v1/customers"},
+	)
+
+	var already *connectorsclient.AlreadyRunningError
+	if !errors.As(err, &already) {
+		t.Fatalf("err = %v, want *AlreadyRunningError", err)
+	}
+	if already.JobID() != "opjob_blocker123" {
+		t.Errorf("JobID = %q, want opjob_blocker123", already.JobID())
+	}
+	if already.Body.Kind != "pull" {
+		t.Errorf("Kind = %q, want pull", already.Body.Kind)
+	}
+	if !errors.Is(err, connectorsclient.ErrOperationAlreadyRunning) {
+		t.Errorf("errors.Is(err, ErrOperationAlreadyRunning) = false, want true")
+	}
+}
+
+// TestStartOperationPull_AlreadyRunning_LegacyFallback verifies that
+// a 409 from a pre-envelope server (just {"error": "..."} with no
+// JobID) still surfaces as *APIError so the operator diagnostics are
+// preserved, rather than claiming a fake structured error.
+func TestStartOperationPull_AlreadyRunning_LegacyFallback(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusConflict)
+		// Legacy-style body with the canonical Error string. Absent
+		// JobID is acceptable per the AlreadyRunningBody contract —
+		// we still treat this as structured.
+		_, _ = w.Write([]byte(`{"error":"Operation is already running"}`))
+	}))
+	defer srv.Close()
+
+	c := connectorsclient.NewClient(srv.URL, "tok", "en")
+	_, err := c.StartOperationPull(
+		context.Background(),
+		connectorsclient.StartOperationPullRequest{Path: "/v1/customers"},
+	)
+
+	var already *connectorsclient.AlreadyRunningError
+	if !errors.As(err, &already) {
+		t.Fatalf("err = %v, want *AlreadyRunningError for canonical body", err)
+	}
+	if already.JobID() != "" {
+		t.Errorf("JobID = %q, want empty for legacy body", already.JobID())
+	}
+	// Error() on an empty-JobID AlreadyRunningError includes the
+	// "retry later" hint so operators know cancel is not actionable.
+	if msg := already.Error(); msg == "" {
+		t.Errorf("empty Error() string on legacy AlreadyRunningError")
+	}
+}
+
+// TestStartOperationPull_AlreadyRunning_Garbled verifies that a 409
+// with garbled JSON falls back to *APIError rather than falsely
+// claiming *AlreadyRunningError.
+func TestStartOperationPull_AlreadyRunning_Garbled(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusConflict)
+		_, _ = w.Write([]byte(`this is not json`))
+	}))
+	defer srv.Close()
+
+	c := connectorsclient.NewClient(srv.URL, "tok", "en")
+	_, err := c.StartOperationPull(
+		context.Background(),
+		connectorsclient.StartOperationPullRequest{Path: "/x"},
+	)
+
+	var apiErr *connectorsclient.APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("err = %v, want *APIError fallback", err)
+	}
+	if apiErr.StatusCode != http.StatusConflict {
+		t.Errorf("StatusCode = %d, want 409", apiErr.StatusCode)
+	}
+	// And ensure we did NOT claim a structured error.
+	var already *connectorsclient.AlreadyRunningError
+	if errors.As(err, &already) {
+		t.Errorf("got *AlreadyRunningError for garbled body, want *APIError")
+	}
+}
+
+// TestGetOperationJobStatus_StructuredError verifies that a 500
+// carrying a JobErrorBody unwraps into *JobServerError with the
+// machine-readable Reason + Retryable fields intact.
+func TestGetOperationJobStatus_StructuredError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_ = json.NewEncoder(w).Encode(irminmodels.JobErrorBody{
+			Error:     "db connection reset",
+			Reason:    irminmodels.JobErrorReasonTransientDB,
+			Retryable: true,
+			JobID:     "opjob_test",
+		})
+	}))
+	defer srv.Close()
+
+	c := connectorsclient.NewClient(srv.URL, "tok", "en")
+	_, err := c.GetOperationJobStatus(context.Background(), "opjob_test")
+
+	var jobErr *connectorsclient.JobServerError
+	if !errors.As(err, &jobErr) {
+		t.Fatalf("err = %v, want *JobServerError", err)
+	}
+	if jobErr.StatusCode != http.StatusInternalServerError {
+		t.Errorf("StatusCode = %d, want 500", jobErr.StatusCode)
+	}
+	if jobErr.Reason() != irminmodels.JobErrorReasonTransientDB {
+		t.Errorf("Reason = %q, want %q", jobErr.Reason(), irminmodels.JobErrorReasonTransientDB)
+	}
+	if !jobErr.Retryable() {
+		t.Errorf("Retryable = false, want true")
+	}
+	if jobErr.Body.JobID != "opjob_test" {
+		t.Errorf("Body.JobID = %q, want opjob_test", jobErr.Body.JobID)
+	}
+}
+
+// TestGetOperationJobStatus_LegacyErrorFallback verifies that a 500
+// from a pre-envelope server falls back to *APIError so operator
+// diagnostics continue to work during the rollout.
+func TestGetOperationJobStatus_LegacyErrorFallback(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error":"failed to load job"}`))
+	}))
+	defer srv.Close()
+
+	c := connectorsclient.NewClient(srv.URL, "tok", "en")
+	_, err := c.GetOperationJobStatus(context.Background(), "opjob_test")
+
+	var apiErr *connectorsclient.APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("err = %v, want *APIError for legacy body", err)
+	}
+	if apiErr.StatusCode != http.StatusInternalServerError {
+		t.Errorf("StatusCode = %d, want 500", apiErr.StatusCode)
+	}
+	if apiErr.Body == "" {
+		t.Errorf("APIError.Body is empty; expected the legacy JSON to survive fallback")
+	}
+	var jobErr *connectorsclient.JobServerError
+	if errors.As(err, &jobErr) {
+		t.Errorf("got *JobServerError for legacy body, want *APIError")
+	}
+}
+
+// TestGetOperationJobStatus_NotFoundStructured verifies 404 envelope
+// handling — Retryable should be false so the caller aborts.
+func TestGetOperationJobStatus_NotFoundStructured(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_ = json.NewEncoder(w).Encode(irminmodels.JobErrorBody{
+			Error:     "job not found",
+			Reason:    irminmodels.JobErrorReasonNotFound,
+			Retryable: false,
+		})
+	}))
+	defer srv.Close()
+
+	c := connectorsclient.NewClient(srv.URL, "tok", "en")
+	_, err := c.GetOperationJobStatus(context.Background(), "opjob_gone")
+
+	var jobErr *connectorsclient.JobServerError
+	if !errors.As(err, &jobErr) {
+		t.Fatalf("err = %v, want *JobServerError", err)
+	}
+	if jobErr.Reason() != irminmodels.JobErrorReasonNotFound {
+		t.Errorf("Reason = %q, want not_found", jobErr.Reason())
+	}
+	if jobErr.Retryable() {
+		t.Errorf("Retryable = true, want false for not_found")
+	}
+}
+
+// TestFetchOperationResult_StructuredError verifies that a 500 on
+// the result endpoint surfaces the structured envelope (the 409-as-
+// not-ready shortcut still wins for 409, tested elsewhere).
+func TestFetchOperationResult_StructuredError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_ = json.NewEncoder(w).Encode(irminmodels.JobErrorBody{
+			Error:     "result file reaped",
+			Reason:    irminmodels.JobErrorReasonCorruptedRow,
+			Retryable: false,
+			JobID:     "opjob_test",
+		})
+	}))
+	defer srv.Close()
+
+	c := connectorsclient.NewClient(srv.URL, "tok", "en")
+	rc, err := c.FetchOperationResult(context.Background(), "opjob_test")
+	if rc != nil {
+		_ = rc.Close()
+		t.Fatalf("expected nil reader on server error")
+	}
+
+	var jobErr *connectorsclient.JobServerError
+	if !errors.As(err, &jobErr) {
+		t.Fatalf("err = %v, want *JobServerError", err)
+	}
+	if jobErr.Reason() != irminmodels.JobErrorReasonCorruptedRow {
+		t.Errorf("Reason = %q, want corrupted_job_state", jobErr.Reason())
+	}
+}
+
+// TestFetchOperationResult_409_PrefersErrResultNotReady verifies the
+// 409-as-not-ready shortcut is preserved even if the body carries a
+// structured reason. Core's poll wrapper keys off ErrResultNotReady
+// for the "keep polling" signal; we do not want the new envelope
+// path to change that contract.
+func TestFetchOperationResult_409_PrefersErrResultNotReady(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusConflict)
+		// A structured body on a 409 would technically match
+		// *JobServerError; assert the not-ready sentinel still wins.
+		_ = json.NewEncoder(w).Encode(irminmodels.JobErrorBody{
+			Error:     "job not ready",
+			Reason:    irminmodels.JobErrorReasonInternal,
+			Retryable: true,
+		})
+	}))
+	defer srv.Close()
+
+	c := connectorsclient.NewClient(srv.URL, "tok", "en")
+	rc, err := c.FetchOperationResult(context.Background(), "opjob_test")
+	if rc != nil {
+		_ = rc.Close()
+		t.Fatalf("expected nil reader")
+	}
+	if !errors.Is(err, connectorsclient.ErrResultNotReady) {
+		t.Fatalf("err = %v, want ErrResultNotReady", err)
+	}
+}
+
+// TestCancelOperationJobDetail_StructuredSuccess verifies that the
+// richer response shape is parsed when the server returns it.
+func TestCancelOperationJobDetail_StructuredSuccess(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(irminmodels.CancelOperationJobResponse{
+			JobID:     "opjob_test",
+			Status:    irminmodels.OperationJobStatusRunning,
+			WasActive: true,
+			Message:   "cancellation requested",
+		})
+	}))
+	defer srv.Close()
+
+	c := connectorsclient.NewClient(srv.URL, "tok", "en")
+	got, err := c.CancelOperationJobDetail(context.Background(), "opjob_test")
+	if err != nil {
+		t.Fatalf("CancelOperationJobDetail: %v", err)
+	}
+	if got.JobID != "opjob_test" {
+		t.Errorf("JobID = %q, want opjob_test", got.JobID)
+	}
+	if !got.WasActive {
+		t.Errorf("WasActive = false, want true")
+	}
+	if got.Status != irminmodels.OperationJobStatusRunning {
+		t.Errorf("Status = %q, want running", got.Status)
+	}
+}
+
+// TestCancelOperationJobDetail_LegacyMessageBody verifies that a
+// legacy server returning {"message": "cancellation requested"}
+// without the richer fields doesn't fail the client — it gets the
+// zero-valued response which is the documented legacy signal.
+func TestCancelOperationJobDetail_LegacyMessageBody(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"message":"cancellation requested"}`))
+	}))
+	defer srv.Close()
+
+	c := connectorsclient.NewClient(srv.URL, "tok", "en")
+	got, err := c.CancelOperationJobDetail(context.Background(), "opjob_test")
+	if err != nil {
+		t.Fatalf("CancelOperationJobDetail: %v", err)
+	}
+	// Legacy body: Status/JobID/WasActive are zero values; Message
+	// rides through because it's a shared field.
+	if got.Message != "cancellation requested" {
+		t.Errorf("Message = %q, want cancellation requested", got.Message)
+	}
+	if got.JobID != "" {
+		t.Errorf("JobID = %q, want empty on legacy body", got.JobID)
+	}
+	if got.WasActive {
+		t.Errorf("WasActive = true, want false on legacy body")
+	}
+}
+
+// TestCancelOperationJob_BackCompat verifies the original
+// fire-and-forget CancelOperationJob still returns nil on 2xx and a
+// structured error on non-2xx.
+func TestCancelOperationJob_BackCompat(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	c := connectorsclient.NewClient(srv.URL, "tok", "en")
+	if err := c.CancelOperationJob(context.Background(), "opjob_test"); err != nil {
+		t.Fatalf("CancelOperationJob: %v", err)
+	}
+}
+
+// TestCancelOperationJob_StructuredError verifies that a 500 on
+// cancel surfaces as *JobServerError so the retry policy can read
+// Retryable without parsing the body.
+func TestCancelOperationJob_StructuredError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_ = json.NewEncoder(w).Encode(irminmodels.JobErrorBody{
+			Error:     "db pool exhausted",
+			Reason:    irminmodels.JobErrorReasonTransientDB,
+			Retryable: true,
+		})
+	}))
+	defer srv.Close()
+
+	c := connectorsclient.NewClient(srv.URL, "tok", "en")
+	err := c.CancelOperationJob(context.Background(), "opjob_test")
+
+	var jobErr *connectorsclient.JobServerError
+	if !errors.As(err, &jobErr) {
+		t.Fatalf("err = %v, want *JobServerError", err)
+	}
+	if !jobErr.Retryable() {
+		t.Errorf("Retryable = false, want true")
+	}
+}
+
+// TestAlreadyRunningError_Unwrap verifies the errors.Is / errors.As
+// behaviour documented for AlreadyRunningError, so callers can use
+// the sentinel check without losing access to the job_id.
+func TestAlreadyRunningError_Unwrap(t *testing.T) {
+	err := &connectorsclient.AlreadyRunningError{
+		Body: irminmodels.AlreadyRunningBody{
+			Error: "Operation is already running",
+			JobID: "opjob_test",
+			Kind:  "pull",
+		},
+	}
+	if !errors.Is(err, connectorsclient.ErrOperationAlreadyRunning) {
+		t.Errorf("errors.Is(err, ErrOperationAlreadyRunning) = false, want true")
+	}
+	var target *connectorsclient.AlreadyRunningError
+	if !errors.As(err, &target) {
+		t.Fatalf("errors.As failed")
+	}
+	if target.JobID() != "opjob_test" {
+		t.Errorf("JobID = %q, want opjob_test", target.JobID())
+	}
+}

--- a/docs/docs.md
+++ b/docs/docs.md
@@ -4858,9 +4858,15 @@ type AlreadyRunningBody struct {
     Kind string `json:"kind,omitempty" example:"pull"`
 
     // StartedAt is when the in-flight job was accepted. Clients can
-    // compute elapsed time to decide whether to wait or cancel. May
-    // be the zero time for legacy sync holders with no row.
-    StartedAt time.Time `json:"started_at,omitempty"`
+    // compute elapsed time to decide whether to wait or cancel. nil
+    // for legacy sync holders with no registered row.
+    //
+    // Pointer rather than time.Time + omitempty because encoding/json's
+    // omitempty does not treat a zero time.Time as empty — it would
+    // serialise as "0001-01-01T00:00:00Z" on the wire. Matches the
+    // convention used by ExpiresAt above and the *time.Time fields
+    // in the other models in this package.
+    StartedAt *time.Time `json:"started_at,omitempty"`
 }
 ```
 

--- a/docs/docs.md
+++ b/docs/docs.md
@@ -3711,9 +3711,14 @@ Consumers that only need the async protocol \(tests, tooling\) can use this pack
 - [Variables](<#variables>)
 - [type APIError](<#APIError>)
   - [func \(e \*APIError\) Error\(\) string](<#APIError.Error>)
+- [type AlreadyRunningError](<#AlreadyRunningError>)
+  - [func \(e \*AlreadyRunningError\) Error\(\) string](<#AlreadyRunningError.Error>)
+  - [func \(e \*AlreadyRunningError\) JobID\(\) string](<#AlreadyRunningError.JobID>)
+  - [func \(e \*AlreadyRunningError\) Unwrap\(\) error](<#AlreadyRunningError.Unwrap>)
 - [type Client](<#Client>)
   - [func NewClient\(baseURL, token, locale string\) \*Client](<#NewClient>)
   - [func \(c \*Client\) CancelOperationJob\(ctx context.Context, jobID string\) error](<#Client.CancelOperationJob>)
+  - [func \(c \*Client\) CancelOperationJobDetail\(ctx context.Context, jobID string\) \(\*irminmodels.CancelOperationJobResponse, error\)](<#Client.CancelOperationJobDetail>)
   - [func \(c \*Client\) FetchOperationResult\(ctx context.Context, jobID string\) \(io.ReadCloser, error\)](<#Client.FetchOperationResult>)
   - [func \(c \*Client\) GetOperationJobStatus\(ctx context.Context, jobID string\) \(\*irminmodels.OperationJobStatusResponse, error\)](<#Client.GetOperationJobStatus>)
   - [func \(c \*Client\) StartOperationPull\(ctx context.Context, req StartOperationPullRequest\) \(\*irminmodels.StartOperationPullResponse, error\)](<#Client.StartOperationPull>)
@@ -3721,6 +3726,10 @@ Consumers that only need the async protocol \(tests, tooling\) can use this pack
 - [type JobFailedError](<#JobFailedError>)
   - [func \(e \*JobFailedError\) Error\(\) string](<#JobFailedError.Error>)
   - [func \(e \*JobFailedError\) Unwrap\(\) error](<#JobFailedError.Unwrap>)
+- [type JobServerError](<#JobServerError>)
+  - [func \(e \*JobServerError\) Error\(\) string](<#JobServerError.Error>)
+  - [func \(e \*JobServerError\) Reason\(\) irminmodels.JobErrorReason](<#JobServerError.Reason>)
+  - [func \(e \*JobServerError\) Retryable\(\) bool](<#JobServerError.Retryable>)
 - [type StartOperationPullRequest](<#StartOperationPullRequest>)
 
 
@@ -3748,6 +3757,14 @@ var ErrJobFailed = errors.New("operation job ended in a non-success terminal sta
 var ErrLegacySyncPullResponse = errors.New(
     "connector returned legacy synchronous pull response (HTTP 200 with body); " +
         "expected 202 Accepted from async protocol — upgrade the connector service",
+)
+```
+
+<a name="ErrOperationAlreadyRunning"></a>ErrOperationAlreadyRunning is the sentinel returned when a connector refuses a request because the same operation is already in flight \(HTTP 409\). Callers wrap this with AlreadyRunningError to surface the job\_id of the blocker; use errors.As to unwrap.
+
+```go
+var ErrOperationAlreadyRunning = errors.New(
+    "connector refused the request: operation is already running",
 )
 ```
 
@@ -3782,6 +3799,49 @@ func (e *APIError) Error() string
 ```
 
 Error implements the error interface.
+
+<a name="AlreadyRunningError"></a>
+## type AlreadyRunningError
+
+AlreadyRunningError wraps ErrOperationAlreadyRunning with the details of the currently\-running job so callers can redirect their polling \(or issue a cancel\) without a second round\-trip to the server to discover what's holding the lock.
+
+Returned by StartOperationPull \(and any other op\-start path that migrates onto the async protocol\) when the server responds with HTTP 409 \+ an AlreadyRunningBody payload.
+
+```go
+type AlreadyRunningError struct {
+    // Body is the full structured payload the server returned. JobID
+    // is the most useful field for callers, but Kind / StartedAt /
+    // OperationID are kept for logs and operator diagnostics.
+    Body irminmodels.AlreadyRunningBody
+}
+```
+
+<a name="AlreadyRunningError.Error"></a>
+### func \(\*AlreadyRunningError\) Error
+
+```go
+func (e *AlreadyRunningError) Error() string
+```
+
+Error implements the error interface.
+
+<a name="AlreadyRunningError.JobID"></a>
+### func \(\*AlreadyRunningError\) JobID
+
+```go
+func (e *AlreadyRunningError) JobID() string
+```
+
+JobID is a convenience accessor for the most commonly consumed field so callers don't have to reach through Body every time.
+
+<a name="AlreadyRunningError.Unwrap"></a>
+### func \(\*AlreadyRunningError\) Unwrap
+
+```go
+func (e *AlreadyRunningError) Unwrap() error
+```
+
+Unwrap lets errors.Is\(err, ErrOperationAlreadyRunning\) succeed on wrapped AlreadyRunningError values, matching the pattern used by JobFailedError.
 
 <a name="Client"></a>
 ## type Client
@@ -3838,6 +3898,19 @@ func (c *Client) CancelOperationJob(ctx context.Context, jobID string) error
 ```
 
 CancelOperationJob requests that the connector service cancel an in\-flight async operation job. Safe to call on terminal jobs \(server is expected to treat it as a no\-op\). Uses POST with the job\_id on the path so it composes with existing per\-job routes.
+
+Returns nil on any 2xx; the richer response shape \(status, was\_active\) is available via CancelOperationJobDetail. Callers that only need idempotent fire\-and\-forget semantics can keep calling this method.
+
+<a name="Client.CancelOperationJobDetail"></a>
+### func \(\*Client\) CancelOperationJobDetail
+
+```go
+func (c *Client) CancelOperationJobDetail(ctx context.Context, jobID string) (*irminmodels.CancelOperationJobResponse, error)
+```
+
+CancelOperationJobDetail is the richer form of CancelOperationJob that returns the parsed CancelOperationJobResponse on success so callers can tell "we actually signalled a running worker" \(WasActive=true\) from "job was already terminal" \(WasActive=false\).
+
+Servers that pre\-date the structured response shape will return a 200 without WasActive; in that case the response carries the default zero values \(Status="", WasActive=false\) and callers should treat that as the legacy "accepted, unknown state" signal.
 
 <a name="Client.FetchOperationResult"></a>
 ### func \(\*Client\) FetchOperationResult
@@ -3928,6 +4001,54 @@ func (e *JobFailedError) Unwrap() error
 ```
 
 Unwrap lets errors.Is\(err, ErrJobFailed\) succeed on wrapped JobFailedError values, so callers can check the sentinel and then use errors.As to extract the detail.
+
+<a name="JobServerError"></a>
+## type JobServerError
+
+JobServerError wraps a structured JobErrorBody returned by the async\-job endpoints \(status/result/cancel\) on any non\-2xx response. Callers driving retry logic should inspect Retryable and Reason rather than the raw Error string.
+
+Returned by GetOperationJobStatus, FetchOperationResult, and CancelOperationJob when the server responds with a structured JobErrorBody payload. For older servers that still return the unstructured \{"error": "..."\} shape, the client falls back to APIError so this type only surfaces on migrated deployments.
+
+```go
+type JobServerError struct {
+    // StatusCode is the HTTP status returned by the connector. Kept
+    // separately from Body so callers can discriminate 404 vs 500
+    // without re-parsing the reason code.
+    StatusCode int
+
+    // Body is the structured error envelope. Reason and Retryable
+    // are the machine-readable signals; Error carries the
+    // operator-facing message.
+    Body irminmodels.JobErrorBody
+}
+```
+
+<a name="JobServerError.Error"></a>
+### func \(\*JobServerError\) Error
+
+```go
+func (e *JobServerError) Error() string
+```
+
+Error implements the error interface.
+
+<a name="JobServerError.Reason"></a>
+### func \(\*JobServerError\) Reason
+
+```go
+func (e *JobServerError) Reason() irminmodels.JobErrorReason
+```
+
+Reason returns the machine\-readable failure classification.
+
+<a name="JobServerError.Retryable"></a>
+### func \(\*JobServerError\) Retryable
+
+```go
+func (e *JobServerError) Retryable() bool
+```
+
+Retryable reports whether the server classified this failure as safe to retry after a short backoff.
 
 <a name="StartOperationPullRequest"></a>
 ## type StartOperationPullRequest
@@ -4297,11 +4418,13 @@ import "github.com/IrminData/irmin-sdk-go/models"
 - [type APIToken](<#APIToken>)
 - [type ActionExecutableType](<#ActionExecutableType>)
 - [type ActionInputData](<#ActionInputData>)
+- [type AlreadyRunningBody](<#AlreadyRunningBody>)
 - [type BillingAddress](<#BillingAddress>)
 - [type BillingInfo](<#BillingInfo>)
 - [type BillingInfoTaxID](<#BillingInfoTaxID>)
 - [type Branch](<#Branch>)
 - [type BranchGarbageCollectionRules](<#BranchGarbageCollectionRules>)
+- [type CancelOperationJobResponse](<#CancelOperationJobResponse>)
 - [type ChangeItem](<#ChangeItem>)
 - [type ChangeType](<#ChangeType>)
 - [type Commit](<#Commit>)
@@ -4337,6 +4460,8 @@ import "github.com/IrminData/irmin-sdk-go/models"
 - [type IrminAPIPaginationMetadata](<#IrminAPIPaginationMetadata>)
 - [type IrminAPIResponse](<#IrminAPIResponse>)
 - [type JSONSchema](<#JSONSchema>)
+- [type JobErrorBody](<#JobErrorBody>)
+- [type JobErrorReason](<#JobErrorReason>)
 - [type LogEvent](<#LogEvent>)
 - [type LogEventType](<#LogEventType>)
 - [type MergeStrategy](<#MergeStrategy>)
@@ -4699,6 +4824,46 @@ type ActionInputData struct {
 }
 ```
 
+<a name="AlreadyRunningBody"></a>
+## type AlreadyRunningBody
+
+AlreadyRunningBody is the wire shape returned by any connector endpoint that refuses a request because the same operation is already in flight \(HTTP 409 Conflict\).
+
+The pre\-async protocol returned just \{"error": "Operation is already running"\} — opaque to callers. This body carries the in\-flight job\_id so callers can redirect their polling \(or cancel the blocker\) without guessing.
+
+JobID is guaranteed non\-empty when the server side uses the unified JobManager.Begin path. It may be empty when a legacy sync code path holds the lock without registering a job row; callers should treat that as "retry later" rather than a hard error.
+
+```go
+type AlreadyRunningBody struct {
+    // Error is the stable human-readable message. Always
+    // "Operation is already running" — kept for backwards
+    // compatibility with clients that key off the error string.
+    Error string `json:"error" example:"Operation is already running"`
+
+    // JobID is the opaque identifier of the currently-running job.
+    // Clients can pass this straight to CancelOperationJob or
+    // GetOperationJobStatus. Empty only for legacy holders that have
+    // not migrated to the JobManager.Begin path yet.
+    JobID string `json:"job_id,omitempty" example:"opjob_9m3x7k2n8q5p"`
+
+    // OperationID is the connector-service-local numeric ID of the
+    // operation the lock was taken on. Present so operator-facing
+    // logs can cross-reference the operation row directly.
+    OperationID uint `json:"operation_id,omitempty" example:"42"`
+
+    // Kind is the operation kind holding the lock. One of "pull",
+    // "push", "patch", "schema". Helps operators distinguish a
+    // long-running pull from a fast sync push when triaging
+    // contention.
+    Kind string `json:"kind,omitempty" example:"pull"`
+
+    // StartedAt is when the in-flight job was accepted. Clients can
+    // compute elapsed time to decide whether to wait or cancel. May
+    // be the zero time for legacy sync holders with no row.
+    StartedAt time.Time `json:"started_at,omitempty"`
+}
+```
+
 <a name="BillingAddress"></a>
 ## type BillingAddress
 
@@ -4762,6 +4927,39 @@ BranchGarbageCollectionRules represents the garbage collection rules for a branc
 type BranchGarbageCollectionRules struct {
     BranchID      string `json:"branch_id"      validate:"required,validslug"      example:"main"`
     RetentionDays int    `json:"retention_days" validate:"required,gte=0,lte=3650" example:"30"`
+}
+```
+
+<a name="CancelOperationJobResponse"></a>
+## type CancelOperationJobResponse
+
+CancelOperationJobResponse is the 200 body returned by POST /operation/cancel/:job\_id. The endpoint is idempotent — calling it on a terminal \(complete/failed/cancelled\) job still returns 200 — so callers that want to distinguish "we actually signalled a running worker" from "job was already terminal" can inspect WasActive.
+
+A 200 response does NOT mean the worker has exited. Cancel is fire\-and\-forget: the signal is accepted and the worker's context is cancelled, but the worker may still be in its shutdown path for a short window. Poll /operation/status to observe the terminal transition.
+
+```go
+type CancelOperationJobResponse struct {
+    // JobID echoes the ID from the URL so batched responses can be
+    // associated with their requests without re-parsing.
+    JobID string `json:"job_id" example:"opjob_9m3x7k2n8q5p"`
+
+    // Status is the job's current lifecycle state at the moment
+    // cancel was processed. If WasActive is true this will usually
+    // still be "running" (the cancel signal has been sent but the
+    // worker has not yet transitioned). If WasActive is false this
+    // is a terminal status.
+    Status OperationJobStatus `json:"status" example:"running"`
+
+    // WasActive is true when cancel actually signalled a live
+    // worker. False for idempotent no-op calls against terminal
+    // jobs — the request is still a success, but the caller can
+    // distinguish "we cancelled it" from "it was already done".
+    WasActive bool `json:"was_active" example:"true"`
+
+    // Message is a human-readable status line. Kept for log
+    // readability; callers driving UI should use Status + WasActive
+    // instead.
+    Message string `json:"message" example:"cancellation requested"`
 }
 ```
 
@@ -5483,6 +5681,77 @@ type JSONSchema struct {
     XInferredBy         *string            `json:"x-inferred-by,omitempty"                                                                                    example:"duckdb-information_schema"`
     XUnmappedTypes      *[]string          `json:"x-unmapped-types,omitempty"                                                                                 example:"CUSTOM_TYPE,UNKNOWN_TYPE"`
 }
+```
+
+<a name="JobErrorBody"></a>
+## type JobErrorBody
+
+JobErrorBody is the structured error envelope returned by the async\-job endpoints on any non\-2xx response \(404, 409 auth issues, 500\). The legacy unstructured \{"error": "..."\} shape is a proper subset — the Error field is always populated — so middleware tolerant of the legacy shape still reads the message.
+
+Clients driving retry logic should read Reason \+ Retryable rather than parsing Error. Example: Core's poll wrapper retries only when Retryable is true AND Reason is JobErrorReasonTransientDB.
+
+```go
+type JobErrorBody struct {
+    // Error is the operator-facing human-readable message. Stable
+    // enough for log grep but not a machine-readable code.
+    Error string `json:"error" example:"failed to load job"`
+
+    // Reason is the machine-readable failure classification. See
+    // JobErrorReason for the stable value set.
+    Reason JobErrorReason `json:"reason" example:"transient_db_error"`
+
+    // Retryable reports whether the caller should retry the same
+    // request after a short backoff. False for any terminal failure
+    // mode (not_found, corrupted_job_state, invalid_request).
+    Retryable bool `json:"retryable" example:"true"`
+
+    // JobID echoes the ID from the URL when the server could parse
+    // one. Empty for request-level failures (malformed URL, missing
+    // path parameter).
+    JobID string `json:"job_id,omitempty" example:"opjob_9m3x7k2n8q5p"`
+}
+```
+
+<a name="JobErrorReason"></a>
+## type JobErrorReason
+
+JobErrorReason enumerates the machine\-readable failure modes of the /operation/\{status,result,cancel\} endpoints. Stable strings — Core's poll wrapper compares against these values directly.
+
+Retryability is NOT encoded in the reason itself — use the Retryable field on JobErrorBody. Some reasons are retryable in some contexts and not in others \(e.g., a "not\_found" on cancel is terminal for the caller but a "not\_found" during a race with janitor reclaim is benign\).
+
+```go
+type JobErrorReason string
+```
+
+<a name="JobErrorReasonTransientDB"></a>
+
+```go
+const (
+    // JobErrorReasonTransientDB signals a recoverable database-layer
+    // error (connection reset, pool exhaustion, statement timeout).
+    // Callers should retry after a short backoff.
+    JobErrorReasonTransientDB JobErrorReason = "transient_db_error"
+
+    // JobErrorReasonCorruptedRow signals that the job row exists but
+    // its persisted state is unreadable (e.g., malformed progress
+    // JSON). Not retryable — the row needs operator intervention or
+    // janitor reaping.
+    JobErrorReasonCorruptedRow JobErrorReason = "corrupted_job_state"
+
+    // JobErrorReasonNotFound signals that no job with the requested
+    // ID exists. Returned on 404; callers should not retry.
+    JobErrorReasonNotFound JobErrorReason = "not_found"
+
+    // JobErrorReasonInvalidRequest signals that the caller sent a
+    // malformed request (missing job_id, bad token, etc.). Not
+    // retryable without changing the request.
+    JobErrorReasonInvalidRequest JobErrorReason = "invalid_request"
+
+    // JobErrorReasonInternal is the catch-all for failures that
+    // don't fit the other buckets. Not retryable by default; the
+    // response body's human-readable Error field carries detail.
+    JobErrorReasonInternal JobErrorReason = "internal"
+)
 ```
 
 <a name="LogEvent"></a>

--- a/docs/html/github_com_IrminData_irmin-sdk-go_connectorsclient.html
+++ b/docs/html/github_com_IrminData_irmin-sdk-go_connectorsclient.html
@@ -57,6 +57,14 @@ var ErrLegacySyncPullResponse = errors.New(
     rather than attempt a silent fallback, per the "no backward-compat shim"
     decision in the async-pull plan.
 
+var ErrOperationAlreadyRunning = errors.New(
+	"connector refused the request: operation is already running",
+)
+    ErrOperationAlreadyRunning is the sentinel returned when a connector refuses
+    a request because the same operation is already in flight (HTTP 409).
+    Callers wrap this with AlreadyRunningError to surface the job_id of the
+    blocker; use errors.As to unwrap.
+
 var ErrResultNotReady = errors.New(
 	"operation result is not ready: job has not reached terminal status=complete",
 )
@@ -82,6 +90,32 @@ type APIError struct {
 
 func (e *APIError) Error() string
     Error implements the error interface.
+
+type AlreadyRunningError struct {
+	// Body is the full structured payload the server returned. JobID
+	// is the most useful field for callers, but Kind / StartedAt /
+	// OperationID are kept for logs and operator diagnostics.
+	Body irminmodels.AlreadyRunningBody
+}
+    AlreadyRunningError wraps ErrOperationAlreadyRunning with the details of
+    the currently-running job so callers can redirect their polling (or issue a
+    cancel) without a second round-trip to the server to discover what's holding
+    the lock.
+
+    Returned by StartOperationPull (and any other op-start path that migrates
+    onto the async protocol) when the server responds with HTTP 409 + an
+    AlreadyRunningBody payload.
+
+func (e *AlreadyRunningError) Error() string
+    Error implements the error interface.
+
+func (e *AlreadyRunningError) JobID() string
+    JobID is a convenience accessor for the most commonly consumed field so
+    callers don't have to reach through Body every time.
+
+func (e *AlreadyRunningError) Unwrap() error
+    Unwrap lets errors.Is(err, ErrOperationAlreadyRunning) succeed on wrapped
+    AlreadyRunningError values, matching the pattern used by JobFailedError.
 
 type Client struct {
 	// BaseURL is the connector service base, e.g.
@@ -129,6 +163,24 @@ func (c *Client) CancelOperationJob(ctx context.Context, jobID string) error
     async operation job. Safe to call on terminal jobs (server is expected to
     treat it as a no-op). Uses POST with the job_id on the path so it composes
     with existing per-job routes.
+
+    Returns nil on any 2xx; the richer response shape (status, was_active) is
+    available via CancelOperationJobDetail. Callers that only need idempotent
+    fire-and-forget semantics can keep calling this method.
+
+func (c *Client) CancelOperationJobDetail(
+	ctx context.Context,
+	jobID string,
+) (*irminmodels.CancelOperationJobResponse, error)
+    CancelOperationJobDetail is the richer form of CancelOperationJob that
+    returns the parsed CancelOperationJobResponse on success so callers can
+    tell "we actually signalled a running worker" (WasActive=true) from "job was
+    already terminal" (WasActive=false).
+
+    Servers that pre-date the structured response shape will return a 200
+    without WasActive; in that case the response carries the default zero values
+    (Status="", WasActive=false) and callers should treat that as the legacy
+    "accepted, unknown state" signal.
 
 func (c *Client) FetchOperationResult(
 	ctx context.Context,
@@ -210,6 +262,38 @@ func (e *JobFailedError) Unwrap() error
     Unwrap lets errors.Is(err, ErrJobFailed) succeed on wrapped JobFailedError
     values, so callers can check the sentinel and then use errors.As to extract
     the detail.
+
+type JobServerError struct {
+	// StatusCode is the HTTP status returned by the connector. Kept
+	// separately from Body so callers can discriminate 404 vs 500
+	// without re-parsing the reason code.
+	StatusCode int
+
+	// Body is the structured error envelope. Reason and Retryable
+	// are the machine-readable signals; Error carries the
+	// operator-facing message.
+	Body irminmodels.JobErrorBody
+}
+    JobServerError wraps a structured JobErrorBody returned by the async-job
+    endpoints (status/result/cancel) on any non-2xx response. Callers driving
+    retry logic should inspect Retryable and Reason rather than the raw Error
+    string.
+
+    Returned by GetOperationJobStatus, FetchOperationResult, and
+    CancelOperationJob when the server responds with a structured JobErrorBody
+    payload. For older servers that still return the unstructured {"error":
+    "..."} shape, the client falls back to APIError so this type only surfaces
+    on migrated deployments.
+
+func (e *JobServerError) Error() string
+    Error implements the error interface.
+
+func (e *JobServerError) Reason() irminmodels.JobErrorReason
+    Reason returns the machine-readable failure classification.
+
+func (e *JobServerError) Retryable() bool
+    Retryable reports whether the server classified this failure as safe to
+    retry after a short backoff.
 
 type StartOperationPullRequest struct {
 	// Path is the connector-specific resource path being pulled

--- a/docs/html/github_com_IrminData_irmin-sdk-go_models.html
+++ b/docs/html/github_com_IrminData_irmin-sdk-go_models.html
@@ -210,9 +210,15 @@ type AlreadyRunningBody struct {
 	Kind string `json:"kind,omitempty" example:"pull"`
 
 	// StartedAt is when the in-flight job was accepted. Clients can
-	// compute elapsed time to decide whether to wait or cancel. May
-	// be the zero time for legacy sync holders with no row.
-	StartedAt time.Time `json:"started_at,omitempty"`
+	// compute elapsed time to decide whether to wait or cancel. nil
+	// for legacy sync holders with no registered row.
+	//
+	// Pointer rather than time.Time + omitempty because encoding/json's
+	// omitempty does not treat a zero time.Time as empty — it would
+	// serialise as "0001-01-01T00:00:00Z" on the wire. Matches the
+	// convention used by ExpiresAt above and the *time.Time fields
+	// in the other models in this package.
+	StartedAt *time.Time `json:"started_at,omitempty"`
 }
     AlreadyRunningBody is the wire shape returned by any connector endpoint that
     refuses a request because the same operation is already in flight (HTTP 409

--- a/docs/html/github_com_IrminData_irmin-sdk-go_models.html
+++ b/docs/html/github_com_IrminData_irmin-sdk-go_models.html
@@ -186,6 +186,47 @@ type ActionInputData struct {
 	RepositoryPath string `json:"repository_path" validate:"omitempty" example:"/data/customers.csv"`
 }
 
+type AlreadyRunningBody struct {
+	// Error is the stable human-readable message. Always
+	// "Operation is already running" — kept for backwards
+	// compatibility with clients that key off the error string.
+	Error string `json:"error" example:"Operation is already running"`
+
+	// JobID is the opaque identifier of the currently-running job.
+	// Clients can pass this straight to CancelOperationJob or
+	// GetOperationJobStatus. Empty only for legacy holders that have
+	// not migrated to the JobManager.Begin path yet.
+	JobID string `json:"job_id,omitempty" example:"opjob_9m3x7k2n8q5p"`
+
+	// OperationID is the connector-service-local numeric ID of the
+	// operation the lock was taken on. Present so operator-facing
+	// logs can cross-reference the operation row directly.
+	OperationID uint `json:"operation_id,omitempty" example:"42"`
+
+	// Kind is the operation kind holding the lock. One of "pull",
+	// "push", "patch", "schema". Helps operators distinguish a
+	// long-running pull from a fast sync push when triaging
+	// contention.
+	Kind string `json:"kind,omitempty" example:"pull"`
+
+	// StartedAt is when the in-flight job was accepted. Clients can
+	// compute elapsed time to decide whether to wait or cancel. May
+	// be the zero time for legacy sync holders with no row.
+	StartedAt time.Time `json:"started_at,omitempty"`
+}
+    AlreadyRunningBody is the wire shape returned by any connector endpoint that
+    refuses a request because the same operation is already in flight (HTTP 409
+    Conflict).
+
+    The pre-async protocol returned just {"error": "Operation is already
+    running"} — opaque to callers. This body carries the in-flight job_id so
+    callers can redirect their polling (or cancel the blocker) without guessing.
+
+    JobID is guaranteed non-empty when the server side uses the unified
+    JobManager.Begin path. It may be empty when a legacy sync code path holds
+    the lock without registering a job row; callers should treat that as "retry
+    later" rather than a hard error.
+
 type BillingAddress struct {
 	Line1      string `json:"line1"       example:"123 Main St"`
 	Line2      string `json:"line2"       example:"Suite 100"`
@@ -223,6 +264,40 @@ type BranchGarbageCollectionRules struct {
 }
     BranchGarbageCollectionRules represents the garbage collection rules for a
     branch.
+
+type CancelOperationJobResponse struct {
+	// JobID echoes the ID from the URL so batched responses can be
+	// associated with their requests without re-parsing.
+	JobID string `json:"job_id" example:"opjob_9m3x7k2n8q5p"`
+
+	// Status is the job's current lifecycle state at the moment
+	// cancel was processed. If WasActive is true this will usually
+	// still be "running" (the cancel signal has been sent but the
+	// worker has not yet transitioned). If WasActive is false this
+	// is a terminal status.
+	Status OperationJobStatus `json:"status" example:"running"`
+
+	// WasActive is true when cancel actually signalled a live
+	// worker. False for idempotent no-op calls against terminal
+	// jobs — the request is still a success, but the caller can
+	// distinguish "we cancelled it" from "it was already done".
+	WasActive bool `json:"was_active" example:"true"`
+
+	// Message is a human-readable status line. Kept for log
+	// readability; callers driving UI should use Status + WasActive
+	// instead.
+	Message string `json:"message" example:"cancellation requested"`
+}
+    CancelOperationJobResponse is the 200 body returned by POST
+    /operation/cancel/:job_id. The endpoint is idempotent — calling it on a
+    terminal (complete/failed/cancelled) job still returns 200 — so callers that
+    want to distinguish "we actually signalled a running worker" from "job was
+    already terminal" can inspect WasActive.
+
+    A 200 response does NOT mean the worker has exited. Cancel is
+    fire-and-forget: the signal is accepted and the worker's context is
+    cancelled, but the worker may still be in its shutdown path for a short
+    window. Poll /operation/status to observe the terminal transition.
 
 type ChangeItem struct {
 	// Object affected by the change
@@ -709,6 +784,71 @@ type JSONSchema struct {
 }
     JSONSchema represents a JSON Schema for structured data.
 
+type JobErrorBody struct {
+	// Error is the operator-facing human-readable message. Stable
+	// enough for log grep but not a machine-readable code.
+	Error string `json:"error" example:"failed to load job"`
+
+	// Reason is the machine-readable failure classification. See
+	// JobErrorReason for the stable value set.
+	Reason JobErrorReason `json:"reason" example:"transient_db_error"`
+
+	// Retryable reports whether the caller should retry the same
+	// request after a short backoff. False for any terminal failure
+	// mode (not_found, corrupted_job_state, invalid_request).
+	Retryable bool `json:"retryable" example:"true"`
+
+	// JobID echoes the ID from the URL when the server could parse
+	// one. Empty for request-level failures (malformed URL, missing
+	// path parameter).
+	JobID string `json:"job_id,omitempty" example:"opjob_9m3x7k2n8q5p"`
+}
+    JobErrorBody is the structured error envelope returned by the async-job
+    endpoints on any non-2xx response (404, 409 auth issues, 500). The legacy
+    unstructured {"error": "..."} shape is a proper subset — the Error field is
+    always populated — so middleware tolerant of the legacy shape still reads
+    the message.
+
+    Clients driving retry logic should read Reason + Retryable rather than
+    parsing Error. Example: Core's poll wrapper retries only when Retryable is
+    true AND Reason is JobErrorReasonTransientDB.
+
+type JobErrorReason string
+    JobErrorReason enumerates the machine-readable failure modes of the
+    /operation/{status,result,cancel} endpoints. Stable strings — Core's poll
+    wrapper compares against these values directly.
+
+    Retryability is NOT encoded in the reason itself — use the Retryable field
+    on JobErrorBody. Some reasons are retryable in some contexts and not in
+    others (e.g., a "not_found" on cancel is terminal for the caller but a
+    "not_found" during a race with janitor reclaim is benign).
+
+const (
+	// JobErrorReasonTransientDB signals a recoverable database-layer
+	// error (connection reset, pool exhaustion, statement timeout).
+	// Callers should retry after a short backoff.
+	JobErrorReasonTransientDB JobErrorReason = "transient_db_error"
+
+	// JobErrorReasonCorruptedRow signals that the job row exists but
+	// its persisted state is unreadable (e.g., malformed progress
+	// JSON). Not retryable — the row needs operator intervention or
+	// janitor reaping.
+	JobErrorReasonCorruptedRow JobErrorReason = "corrupted_job_state"
+
+	// JobErrorReasonNotFound signals that no job with the requested
+	// ID exists. Returned on 404; callers should not retry.
+	JobErrorReasonNotFound JobErrorReason = "not_found"
+
+	// JobErrorReasonInvalidRequest signals that the caller sent a
+	// malformed request (missing job_id, bad token, etc.). Not
+	// retryable without changing the request.
+	JobErrorReasonInvalidRequest JobErrorReason = "invalid_request"
+
+	// JobErrorReasonInternal is the catch-all for failures that
+	// don't fit the other buckets. Not retryable by default; the
+	// response body's human-readable Error field carries detail.
+	JobErrorReasonInternal JobErrorReason = "internal"
+)
 type LogEvent struct {
 	ID          string       `json:"id"                     validate:"required,validsqid=logs"                                             example:"log_1a2b3c4d"`
 	Type        LogEventType `json:"type"                   validate:"required,oneof=CREATE UPDATE DELETE LOGIN LOGOUT ERROR INFO WARNING" example:"CREATE"`

--- a/docs/html/index.html
+++ b/docs/html/index.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8"/>
 <title>github.com/IrminData/irmin-sdk-go documentation</title>
 <h1>github.com/IrminData/irmin-sdk-go documentation</h1>
-<p>Generated on 2026-04-23 10:00 UTC</p>
+<p>Generated on 2026-04-24 10:12 UTC</p>
 <ul>
 <li><a href="github_com_IrminData_irmin-sdk-go.html">github.com/IrminData/irmin-sdk-go</a></li>
 <li><a href="github_com_IrminData_irmin-sdk-go_api.html">github.com/IrminData/irmin-sdk-go/api</a></li>

--- a/docs/html/index.html
+++ b/docs/html/index.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8"/>
 <title>github.com/IrminData/irmin-sdk-go documentation</title>
 <h1>github.com/IrminData/irmin-sdk-go documentation</h1>
-<p>Generated on 2026-04-24 10:12 UTC</p>
+<p>Generated on 2026-04-24 10:19 UTC</p>
 <ul>
 <li><a href="github_com_IrminData_irmin-sdk-go.html">github.com/IrminData/irmin-sdk-go</a></li>
 <li><a href="github_com_IrminData_irmin-sdk-go_api.html">github.com/IrminData/irmin-sdk-go/api</a></li>

--- a/models/operation_job.go
+++ b/models/operation_job.go
@@ -192,9 +192,15 @@ type AlreadyRunningBody struct {
 	Kind string `json:"kind,omitempty" example:"pull"`
 
 	// StartedAt is when the in-flight job was accepted. Clients can
-	// compute elapsed time to decide whether to wait or cancel. May
-	// be the zero time for legacy sync holders with no row.
-	StartedAt time.Time `json:"started_at,omitempty"`
+	// compute elapsed time to decide whether to wait or cancel. nil
+	// for legacy sync holders with no registered row.
+	//
+	// Pointer rather than time.Time + omitempty because encoding/json's
+	// omitempty does not treat a zero time.Time as empty — it would
+	// serialise as "0001-01-01T00:00:00Z" on the wire. Matches the
+	// convention used by ExpiresAt above and the *time.Time fields
+	// in the other models in this package.
+	StartedAt *time.Time `json:"started_at,omitempty"`
 }
 
 // JobErrorReason enumerates the machine-readable failure modes of

--- a/models/operation_job.go
+++ b/models/operation_job.go
@@ -154,3 +154,148 @@ type StartOperationPullResponse struct {
 	// /operation/status and /operation/result calls.
 	JobID string `json:"job_id" example:"opjob_9m3x7k2n8q5p"`
 }
+
+// AlreadyRunningBody is the wire shape returned by any connector
+// endpoint that refuses a request because the same operation is
+// already in flight (HTTP 409 Conflict).
+//
+// The pre-async protocol returned just {"error": "Operation is already
+// running"} — opaque to callers. This body carries the in-flight
+// job_id so callers can redirect their polling (or cancel the
+// blocker) without guessing.
+//
+// JobID is guaranteed non-empty when the server side uses the unified
+// JobManager.Begin path. It may be empty when a legacy sync code path
+// holds the lock without registering a job row; callers should treat
+// that as "retry later" rather than a hard error.
+type AlreadyRunningBody struct {
+	// Error is the stable human-readable message. Always
+	// "Operation is already running" — kept for backwards
+	// compatibility with clients that key off the error string.
+	Error string `json:"error" example:"Operation is already running"`
+
+	// JobID is the opaque identifier of the currently-running job.
+	// Clients can pass this straight to CancelOperationJob or
+	// GetOperationJobStatus. Empty only for legacy holders that have
+	// not migrated to the JobManager.Begin path yet.
+	JobID string `json:"job_id,omitempty" example:"opjob_9m3x7k2n8q5p"`
+
+	// OperationID is the connector-service-local numeric ID of the
+	// operation the lock was taken on. Present so operator-facing
+	// logs can cross-reference the operation row directly.
+	OperationID uint `json:"operation_id,omitempty" example:"42"`
+
+	// Kind is the operation kind holding the lock. One of "pull",
+	// "push", "patch", "schema". Helps operators distinguish a
+	// long-running pull from a fast sync push when triaging
+	// contention.
+	Kind string `json:"kind,omitempty" example:"pull"`
+
+	// StartedAt is when the in-flight job was accepted. Clients can
+	// compute elapsed time to decide whether to wait or cancel. May
+	// be the zero time for legacy sync holders with no row.
+	StartedAt time.Time `json:"started_at,omitempty"`
+}
+
+// JobErrorReason enumerates the machine-readable failure modes of
+// the /operation/{status,result,cancel} endpoints. Stable strings —
+// Core's poll wrapper compares against these values directly.
+//
+// Retryability is NOT encoded in the reason itself — use the
+// Retryable field on JobErrorBody. Some reasons are retryable in
+// some contexts and not in others (e.g., a "not_found" on cancel is
+// terminal for the caller but a "not_found" during a race with
+// janitor reclaim is benign).
+type JobErrorReason string
+
+const (
+	// JobErrorReasonTransientDB signals a recoverable database-layer
+	// error (connection reset, pool exhaustion, statement timeout).
+	// Callers should retry after a short backoff.
+	JobErrorReasonTransientDB JobErrorReason = "transient_db_error"
+
+	// JobErrorReasonCorruptedRow signals that the job row exists but
+	// its persisted state is unreadable (e.g., malformed progress
+	// JSON). Not retryable — the row needs operator intervention or
+	// janitor reaping.
+	JobErrorReasonCorruptedRow JobErrorReason = "corrupted_job_state"
+
+	// JobErrorReasonNotFound signals that no job with the requested
+	// ID exists. Returned on 404; callers should not retry.
+	JobErrorReasonNotFound JobErrorReason = "not_found"
+
+	// JobErrorReasonInvalidRequest signals that the caller sent a
+	// malformed request (missing job_id, bad token, etc.). Not
+	// retryable without changing the request.
+	JobErrorReasonInvalidRequest JobErrorReason = "invalid_request"
+
+	// JobErrorReasonInternal is the catch-all for failures that
+	// don't fit the other buckets. Not retryable by default; the
+	// response body's human-readable Error field carries detail.
+	JobErrorReasonInternal JobErrorReason = "internal"
+)
+
+// JobErrorBody is the structured error envelope returned by the
+// async-job endpoints on any non-2xx response (404, 409 auth issues,
+// 500). The legacy unstructured {"error": "..."} shape is a proper
+// subset — the Error field is always populated — so middleware
+// tolerant of the legacy shape still reads the message.
+//
+// Clients driving retry logic should read Reason + Retryable rather
+// than parsing Error. Example: Core's poll wrapper retries only when
+// Retryable is true AND Reason is JobErrorReasonTransientDB.
+type JobErrorBody struct {
+	// Error is the operator-facing human-readable message. Stable
+	// enough for log grep but not a machine-readable code.
+	Error string `json:"error" example:"failed to load job"`
+
+	// Reason is the machine-readable failure classification. See
+	// JobErrorReason for the stable value set.
+	Reason JobErrorReason `json:"reason" example:"transient_db_error"`
+
+	// Retryable reports whether the caller should retry the same
+	// request after a short backoff. False for any terminal failure
+	// mode (not_found, corrupted_job_state, invalid_request).
+	Retryable bool `json:"retryable" example:"true"`
+
+	// JobID echoes the ID from the URL when the server could parse
+	// one. Empty for request-level failures (malformed URL, missing
+	// path parameter).
+	JobID string `json:"job_id,omitempty" example:"opjob_9m3x7k2n8q5p"`
+}
+
+// CancelOperationJobResponse is the 200 body returned by
+// POST /operation/cancel/:job_id. The endpoint is idempotent —
+// calling it on a terminal (complete/failed/cancelled) job still
+// returns 200 — so callers that want to distinguish "we actually
+// signalled a running worker" from "job was already terminal" can
+// inspect WasActive.
+//
+// A 200 response does NOT mean the worker has exited. Cancel is
+// fire-and-forget: the signal is accepted and the worker's context
+// is cancelled, but the worker may still be in its shutdown path
+// for a short window. Poll /operation/status to observe the
+// terminal transition.
+type CancelOperationJobResponse struct {
+	// JobID echoes the ID from the URL so batched responses can be
+	// associated with their requests without re-parsing.
+	JobID string `json:"job_id" example:"opjob_9m3x7k2n8q5p"`
+
+	// Status is the job's current lifecycle state at the moment
+	// cancel was processed. If WasActive is true this will usually
+	// still be "running" (the cancel signal has been sent but the
+	// worker has not yet transitioned). If WasActive is false this
+	// is a terminal status.
+	Status OperationJobStatus `json:"status" example:"running"`
+
+	// WasActive is true when cancel actually signalled a live
+	// worker. False for idempotent no-op calls against terminal
+	// jobs — the request is still a success, but the caller can
+	// distinguish "we cancelled it" from "it was already done".
+	WasActive bool `json:"was_active" example:"true"`
+
+	// Message is a human-readable status line. Kept for log
+	// readability; callers driving UI should use Status + WasActive
+	// instead.
+	Message string `json:"message" example:"cancellation requested"`
+}


### PR DESCRIPTION
## Summary
- Adds `AlreadyRunningBody` and `JobErrorBody` wire types so 409/500 responses from the async-op endpoints carry machine-readable `job_id`, `reason`, and `retryable` fields instead of opaque `{"error":"..."}` strings.
- Adds typed errors `AlreadyRunningError` and `JobServerError` (both implement `Unwrap` so `errors.Is`/`errors.As` work cleanly) plus a `CancelOperationJobDetail` form that surfaces whether cancel actually signalled a live worker.
- Pre-envelope connector deployments keep working: any body that doesn't match the structured shape falls back to `*APIError` with the original bytes preserved for operator logs.
- `ErrResultNotReady` still wins on 409 from `/operation/result` — the poll-wrapper contract is unchanged.

## Why
Core's poll wrapper currently can't distinguish transient DB hiccups from unrecoverable job state, and when it hits a 409 "Operation is already running" there's no way to find the blocking job without guessing. These types are the wire-level prerequisite for the connector-service PR that will emit them from every 409/500 call site through a shared `JobManager.Begin` API.

## Test plan
- [x] `go test ./...` — 14 new tests cover structured/legacy/garbled paths on `StartOperationPull`, `GetOperationJobStatus`, `FetchOperationResult`, `CancelOperationJob*`, plus `errors.Is`/`errors.As` on both new typed errors
- [x] `golangci-lint run ./connectorsclient/... ./models/...` — 0 issues
- [ ] Downstream: connector-service PR lands on matching schema; pre-envelope deployments continue to surface `*APIError` for legacy bodies (covered by `TestGetOperationJobStatus_LegacyErrorFallback` and `TestCancelOperationJobDetail_LegacyMessageBody`)

Once merged + tagged, the companion connectors PR pins to the new tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes error-handling semantics and response parsing for async operation endpoints (including new cancel response decoding), which may affect downstream retry/poll logic if callers rely on previous `*APIError` shapes.
> 
> **Overview**
> Adds new structured wire types (`AlreadyRunningBody`, `JobErrorBody`, `JobErrorReason`, `CancelOperationJobResponse`) and client-side typed errors (`AlreadyRunningError` + `ErrOperationAlreadyRunning`, `JobServerError`) so async op endpoints can return machine-readable `job_id`/`reason`/`retryable` data instead of opaque strings.
> 
> Updates async operation methods to prefer these structured errors: `StartOperationPull` now parses HTTP 409 into `AlreadyRunningError`, and status/result/cancel non-2xx responses now decode into `JobServerError` when possible while falling back to `*APIError` when bodies don’t match the envelope; `/operation/result` still returns `ErrResultNotReady` on 409.
> 
> Refactors `CancelOperationJob` to delegate to new `CancelOperationJobDetail`, which parses the (optional) structured 2xx response body, and adds targeted tests + regenerated docs for the new API surface.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 04e3cd39c2cb1975ecb54c1369a7bc47f22e7b6a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->