### PR TITLE
feat(connectorsclient): carry Details + Settings on every Start* request

### DIFF
--- a/connectorsclient/operation_async.go
+++ b/connectorsclient/operation_async.go
@@ -486,11 +486,16 @@ func (j *OperationJob) Wait(
 // application/x-www-form-urlencoded body + the matching headers.
 // Keeps the request surface identical to the pre-async
 // /operation/pull handler so the server-side route does not change
-// shape.
+// shape. Credentials flow through the shared
+// buildDetailsSettingsForm encoder so the wire shape stays in
+// lockstep with the config-field endpoints (the canonical reference
+// for `details[<key>]` / `settings[<key>]` form fields).
 func encodeStartPullForm(req StartOperationPullRequest) (io.Reader, map[string]string) {
 	values := url.Values{}
 	values.Set("path", req.Path)
-	addCredentialFormValues(values, req.Details, req.Settings)
+	for k, v := range buildDetailsSettingsForm(req.Details, req.Settings) {
+		values.Set(k, v)
+	}
 	for k, v := range req.Extra {
 		// Protect against a caller overwriting path via Extra.
 		if k == "path" || isReservedCredentialKey(k) {
@@ -505,31 +510,15 @@ func encodeStartPullForm(req StartOperationPullRequest) (io.Reader, map[string]s
 	return body, headers
 }
 
-// addCredentialFormValues stamps Details / Settings onto a url.Values in
-// the `details[<key>]=<value>` / `settings[<key>]=<value>` shape the
-// connector service's ParseFormFields helper recognises. Pulled out of
-// the per-encoder helpers so pull (urlencoded) and push/patch
-// (multipart formFields map) can share the same wire shape; the
-// connector-side Phase 4 parser keys off these prefixes to upsert the
-// Operation row inline without an /operation/init round-trip.
-func addCredentialFormValues(values url.Values, details, settings map[string]string) {
-	for k, v := range details {
-		values.Set(fmt.Sprintf("details[%s]", k), v)
-	}
-	for k, v := range settings {
-		values.Set(fmt.Sprintf("settings[%s]", k), v)
-	}
-}
-
-// addCredentialFormFields is the multipart-friendly twin of
-// addCredentialFormValues — same wire shape, different in-memory
-// container. Used by buildPushRequestOptions and buildPatchRequestOptions.
-func addCredentialFormFields(formFields, details, settings map[string]string) {
-	for k, v := range details {
-		formFields[fmt.Sprintf("details[%s]", k)] = v
-	}
-	for k, v := range settings {
-		formFields[fmt.Sprintf("settings[%s]", k)] = v
+// mergeCredentialFormFields lifts the single canonical
+// buildDetailsSettingsForm encoder into the in-place merge style the
+// multipart push/patch encoders prefer. One source of truth for the
+// `details[<key>]` / `settings[<key>]` wire shape (defined in
+// config_fields.go); a future format change there propagates here
+// for free.
+func mergeCredentialFormFields(formFields, details, settings map[string]string) {
+	for k, v := range buildDetailsSettingsForm(details, settings) {
+		formFields[k] = v
 	}
 }
 
@@ -570,7 +559,7 @@ func buildPushRequestOptions(req StartOperationPushRequest) (RequestOptions, err
 	if req.Path != "" {
 		formFields["path"] = req.Path
 	}
-	addCredentialFormFields(formFields, req.Details, req.Settings)
+	mergeCredentialFormFields(formFields, req.Details, req.Settings)
 	for k, v := range req.Extra {
 		// Protect against a caller overwriting reserved fields via Extra.
 		if k == "path" || k == "file" || k == "presigned_url" || isReservedCredentialKey(k) {
@@ -641,7 +630,7 @@ func buildPatchRequestOptions(req StartOperationPatchRequest) (RequestOptions, e
 	}
 
 	formFields := map[string]string{}
-	addCredentialFormFields(formFields, req.Details, req.Settings)
+	mergeCredentialFormFields(formFields, req.Details, req.Settings)
 	for k, v := range req.Extra {
 		if k == "patches" || isReservedCredentialKey(k) {
 			continue

--- a/connectorsclient/operation_async.go
+++ b/connectorsclient/operation_async.go
@@ -60,6 +60,28 @@ type StartOperationPullRequest struct {
 	// Postgres). Required.
 	Path string
 
+	// Details carries the connection's external-system credentials
+	// (host / port / API key / TLS cert / etc.) — the same map
+	// shape the pre-async /operation/init handshake used to ship
+	// once and the connector cached on its Operation row.
+	//
+	// After Phase 4, /operation/init is gone; every Start* request
+	// carries the credentials inline so the connector service can
+	// upsert its Operation row on the fly. The wire shape is
+	// `details[<key>]=<value>` form fields, matching what
+	// /operation/init expected so the server-side parser does not
+	// have to change.
+	//
+	// For OAuth-backed connectors, this map is typically empty —
+	// the connector reaches into Core via the SystemOAuthAccessToken
+	// route on every vendor call.
+	Details map[string]string
+
+	// Settings carries workspace-level scoping choices (which
+	// project / schema / folder to pull from). Same wire shape as
+	// Details: `settings[<key>]=<value>` form fields.
+	Settings map[string]string
+
 	// Extra carries any additional form fields the specific
 	// connector accepts on its pull endpoint (cursor, filters,
 	// batch hints). Use for connector-specific parameters — the
@@ -92,6 +114,13 @@ type StartOperationPushRequest struct {
 	// FilePath points at a zip on disk. Used when both PresignedURL
 	// and File are empty.
 	FilePath string
+
+	// Details / Settings carry the connection's credentials and
+	// workspace-level scoping. See StartOperationPullRequest for the
+	// long-form rationale — the same shape applies here.
+	Details  map[string]string
+	Settings map[string]string
+
 	// Extra carries additional form fields (connector-specific).
 	Extra map[string]string
 }
@@ -113,6 +142,13 @@ type StartOperationPatchRequest struct {
 	// FileName is the multipart part filename for the patches field.
 	// Defaults to "patches.json".
 	FileName string
+
+	// Details / Settings carry the connection's credentials and
+	// workspace-level scoping. See StartOperationPullRequest for the
+	// long-form rationale.
+	Details  map[string]string
+	Settings map[string]string
+
 	// Extra carries additional form fields (connector-specific).
 	Extra map[string]string
 }
@@ -454,9 +490,10 @@ func (j *OperationJob) Wait(
 func encodeStartPullForm(req StartOperationPullRequest) (io.Reader, map[string]string) {
 	values := url.Values{}
 	values.Set("path", req.Path)
+	addCredentialFormValues(values, req.Details, req.Settings)
 	for k, v := range req.Extra {
 		// Protect against a caller overwriting path via Extra.
-		if k == "path" {
+		if k == "path" || isReservedCredentialKey(k) {
 			continue
 		}
 		values.Set(k, v)
@@ -466,6 +503,42 @@ func encodeStartPullForm(req StartOperationPullRequest) (io.Reader, map[string]s
 		"Content-Type": "application/x-www-form-urlencoded",
 	}
 	return body, headers
+}
+
+// addCredentialFormValues stamps Details / Settings onto a url.Values in
+// the `details[<key>]=<value>` / `settings[<key>]=<value>` shape the
+// connector service's ParseFormFields helper recognises. Pulled out of
+// the per-encoder helpers so pull (urlencoded) and push/patch
+// (multipart formFields map) can share the same wire shape; the
+// connector-side Phase 4 parser keys off these prefixes to upsert the
+// Operation row inline without an /operation/init round-trip.
+func addCredentialFormValues(values url.Values, details, settings map[string]string) {
+	for k, v := range details {
+		values.Set(fmt.Sprintf("details[%s]", k), v)
+	}
+	for k, v := range settings {
+		values.Set(fmt.Sprintf("settings[%s]", k), v)
+	}
+}
+
+// addCredentialFormFields is the multipart-friendly twin of
+// addCredentialFormValues — same wire shape, different in-memory
+// container. Used by buildPushRequestOptions and buildPatchRequestOptions.
+func addCredentialFormFields(formFields, details, settings map[string]string) {
+	for k, v := range details {
+		formFields[fmt.Sprintf("details[%s]", k)] = v
+	}
+	for k, v := range settings {
+		formFields[fmt.Sprintf("settings[%s]", k)] = v
+	}
+}
+
+// isReservedCredentialKey returns true for raw form keys that overlap
+// the credential channel's wire shape. Used to refuse Extra values
+// that would silently shadow Details/Settings entries; callers that
+// genuinely need those keys should set them on Details / Settings.
+func isReservedCredentialKey(key string) bool {
+	return strings.HasPrefix(key, "details[") || strings.HasPrefix(key, "settings[")
 }
 
 // buildPushRequestOptions composes the multipart body for a push.
@@ -497,9 +570,10 @@ func buildPushRequestOptions(req StartOperationPushRequest) (RequestOptions, err
 	if req.Path != "" {
 		formFields["path"] = req.Path
 	}
+	addCredentialFormFields(formFields, req.Details, req.Settings)
 	for k, v := range req.Extra {
 		// Protect against a caller overwriting reserved fields via Extra.
-		if k == "path" || k == "file" || k == "presigned_url" {
+		if k == "path" || k == "file" || k == "presigned_url" || isReservedCredentialKey(k) {
 			continue
 		}
 		formFields[k] = v
@@ -567,8 +641,9 @@ func buildPatchRequestOptions(req StartOperationPatchRequest) (RequestOptions, e
 	}
 
 	formFields := map[string]string{}
+	addCredentialFormFields(formFields, req.Details, req.Settings)
 	for k, v := range req.Extra {
-		if k == "patches" {
+		if k == "patches" || isReservedCredentialKey(k) {
 			continue
 		}
 		formFields[k] = v

--- a/connectorsclient/operation_async_test.go
+++ b/connectorsclient/operation_async_test.go
@@ -134,6 +134,119 @@ func TestStartOperationPush_ExtraCannotOverwriteReservedFields(t *testing.T) {
 	}
 }
 
+// TestStartOperationPull_CarriesDetailsAndSettings verifies that the
+// Phase-4 credential channel reaches the connector in the
+// `details[<key>]=<value>` / `settings[<key>]=<value>` form-field
+// shape — the same shape /operation/init used to ship once and the
+// connector's existing ParseFormFields parser already understands.
+// Without this, post-init-retirement Start* requests would fail at
+// the worker because no Operation row carries credentials.
+func TestStartOperationPull_CarriesDetailsAndSettings(t *testing.T) {
+	captured := make(map[string]string)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("ParseForm: %v", err)
+		}
+		// Capture every form field so the test can assert both the
+		// presence of expected entries AND the absence of leakage
+		// from Extra into reserved credential slots.
+		for k, vs := range r.Form {
+			if len(vs) > 0 {
+				captured[k] = vs[0]
+			}
+		}
+		w.WriteHeader(http.StatusAccepted)
+		_ = json.NewEncoder(w).Encode(irminmodels.StartOperationJobResponse{
+			JobID:          "opjob_creds",
+			OperationToken: "optk_creds",
+		})
+	}))
+	defer srv.Close()
+
+	c := connectorsclient.NewClient(srv.URL, "tok")
+	_, err := c.StartOperationPull(context.Background(), connectorsclient.StartOperationPullRequest{
+		Path: "/v1/customers",
+		Details: map[string]string{
+			"host":     "db.example",
+			"password": "s3cr3t",
+		},
+		Settings: map[string]string{
+			"schema": "public",
+		},
+		Extra: map[string]string{
+			"cursor": "abc",
+			// Attempting to inject a credential via Extra must be
+			// silently dropped — the encoder uses isReservedCredentialKey
+			// to refuse `details[*]` / `settings[*]` keys in Extra.
+			"details[password]": "tampered",
+		},
+	})
+	if err != nil {
+		t.Fatalf("StartOperationPull: %v", err)
+	}
+
+	want := map[string]string{
+		"path":              "/v1/customers",
+		"details[host]":     "db.example",
+		"details[password]": "s3cr3t",
+		"settings[schema]":  "public",
+		"cursor":            "abc",
+	}
+	for k, v := range want {
+		if captured[k] != v {
+			t.Errorf("form %s = %q, want %q", k, captured[k], v)
+		}
+	}
+	// Extra-supplied "details[password]"="tampered" must NOT have
+	// overwritten the legitimate Details value.
+	if captured["details[password]"] == "tampered" {
+		t.Errorf("Extra.details[password] leaked through and tampered the credential channel")
+	}
+}
+
+// TestStartOperationPatch_CarriesDetailsAndSettings asserts the
+// multipart credential channel works on patch (which uses the same
+// addCredentialFormFields helper). Push exercises the same code path.
+func TestStartOperationPatch_CarriesDetailsAndSettings(t *testing.T) {
+	captured := make(map[string]string)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseMultipartForm(1 << 20); err != nil {
+			t.Fatalf("ParseMultipartForm: %v", err)
+		}
+		for k, vs := range r.MultipartForm.Value {
+			if len(vs) > 0 {
+				captured[k] = vs[0]
+			}
+		}
+		w.WriteHeader(http.StatusAccepted)
+		_ = json.NewEncoder(w).Encode(irminmodels.StartOperationJobResponse{
+			JobID:          "opjob_patch",
+			OperationToken: "optk_patch",
+		})
+	}))
+	defer srv.Close()
+
+	c := connectorsclient.NewClient(srv.URL, "tok")
+	_, err := c.StartOperationPatch(context.Background(), connectorsclient.StartOperationPatchRequest{
+		PatchesJSON: []byte(`[]`),
+		Details: map[string]string{
+			"api_key": "pat_xyz",
+		},
+		Settings: map[string]string{
+			"workspace": "team-a",
+		},
+	})
+	if err != nil {
+		t.Fatalf("StartOperationPatch: %v", err)
+	}
+	if captured["details[api_key]"] != "pat_xyz" {
+		t.Errorf("details[api_key] = %q, want pat_xyz", captured["details[api_key]"])
+	}
+	if captured["settings[workspace]"] != "team-a" {
+		t.Errorf("settings[workspace] = %q, want team-a", captured["settings[workspace]"])
+	}
+}
+
 // TestStartOperationPull_LegacySyncResponse verifies that a 200 OK
 // from an unmigrated connector surfaces the ErrLegacySyncPullResponse
 // sentinel rather than silently degrading to a sync path.

--- a/docs/docs.md
+++ b/docs/docs.md
@@ -4352,6 +4352,13 @@ type StartOperationPatchRequest struct {
     // FileName is the multipart part filename for the patches field.
     // Defaults to "patches.json".
     FileName string
+
+    // Details / Settings carry the connection's credentials and
+    // workspace-level scoping. See StartOperationPullRequest for the
+    // long-form rationale.
+    Details  map[string]string
+    Settings map[string]string
+
     // Extra carries additional form fields (connector-specific).
     Extra map[string]string
 }
@@ -4368,6 +4375,28 @@ type StartOperationPullRequest struct {
     // (e.g., "/v1/customers" for Stripe, a table identifier for
     // Postgres). Required.
     Path string
+
+    // Details carries the connection's external-system credentials
+    // (host / port / API key / TLS cert / etc.) — the same map
+    // shape the pre-async /operation/init handshake used to ship
+    // once and the connector cached on its Operation row.
+    //
+    // After Phase 4, /operation/init is gone; every Start* request
+    // carries the credentials inline so the connector service can
+    // upsert its Operation row on the fly. The wire shape is
+    // `details[<key>]=<value>` form fields, matching what
+    // /operation/init expected so the server-side parser does not
+    // have to change.
+    //
+    // For OAuth-backed connectors, this map is typically empty —
+    // the connector reaches into Core via the SystemOAuthAccessToken
+    // route on every vendor call.
+    Details map[string]string
+
+    // Settings carries workspace-level scoping choices (which
+    // project / schema / folder to pull from). Same wire shape as
+    // Details: `settings[<key>]=<value>` form fields.
+    Settings map[string]string
 
     // Extra carries any additional form fields the specific
     // connector accepts on its pull endpoint (cursor, filters,
@@ -4401,6 +4430,13 @@ type StartOperationPushRequest struct {
     // FilePath points at a zip on disk. Used when both PresignedURL
     // and File are empty.
     FilePath string
+
+    // Details / Settings carry the connection's credentials and
+    // workspace-level scoping. See StartOperationPullRequest for the
+    // long-form rationale — the same shape applies here.
+    Details  map[string]string
+    Settings map[string]string
+
     // Extra carries additional form fields (connector-specific).
     Extra map[string]string
 }

--- a/docs/html/github_com_IrminData_irmin-sdk-go_connectorsclient.html
+++ b/docs/html/github_com_IrminData_irmin-sdk-go_connectorsclient.html
@@ -519,6 +519,13 @@ type StartOperationPatchRequest struct {
 	// FileName is the multipart part filename for the patches field.
 	// Defaults to "patches.json".
 	FileName string
+
+	// Details / Settings carry the connection's credentials and
+	// workspace-level scoping. See StartOperationPullRequest for the
+	// long-form rationale.
+	Details  map[string]string
+	Settings map[string]string
+
 	// Extra carries additional form fields (connector-specific).
 	Extra map[string]string
 }
@@ -535,6 +542,28 @@ type StartOperationPullRequest struct {
 	// (e.g., "/v1/customers" for Stripe, a table identifier for
 	// Postgres). Required.
 	Path string
+
+	// Details carries the connection's external-system credentials
+	// (host / port / API key / TLS cert / etc.) — the same map
+	// shape the pre-async /operation/init handshake used to ship
+	// once and the connector cached on its Operation row.
+	//
+	// After Phase 4, /operation/init is gone; every Start* request
+	// carries the credentials inline so the connector service can
+	// upsert its Operation row on the fly. The wire shape is
+	// `details[&lt;key&gt;]=&lt;value&gt;` form fields, matching what
+	// /operation/init expected so the server-side parser does not
+	// have to change.
+	//
+	// For OAuth-backed connectors, this map is typically empty —
+	// the connector reaches into Core via the SystemOAuthAccessToken
+	// route on every vendor call.
+	Details map[string]string
+
+	// Settings carries workspace-level scoping choices (which
+	// project / schema / folder to pull from). Same wire shape as
+	// Details: `settings[&lt;key&gt;]=&lt;value&gt;` form fields.
+	Settings map[string]string
 
 	// Extra carries any additional form fields the specific
 	// connector accepts on its pull endpoint (cursor, filters,
@@ -564,6 +593,13 @@ type StartOperationPushRequest struct {
 	// FilePath points at a zip on disk. Used when both PresignedURL
 	// and File are empty.
 	FilePath string
+
+	// Details / Settings carry the connection's credentials and
+	// workspace-level scoping. See StartOperationPullRequest for the
+	// long-form rationale — the same shape applies here.
+	Details  map[string]string
+	Settings map[string]string
+
 	// Extra carries additional form fields (connector-specific).
 	Extra map[string]string
 }

--- a/docs/html/index.html
+++ b/docs/html/index.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8"/>
 <title>github.com/IrminData/irmin-sdk-go documentation</title>
 <h1>github.com/IrminData/irmin-sdk-go documentation</h1>
-<p>Generated on 2026-04-25 10:57 UTC</p>
+<p>Generated on 2026-04-25 11:05 UTC</p>
 <ul>
 <li><a href="github_com_IrminData_irmin-sdk-go.html">github.com/IrminData/irmin-sdk-go</a></li>
 <li><a href="github_com_IrminData_irmin-sdk-go_api.html">github.com/IrminData/irmin-sdk-go/api</a></li>

--- a/docs/html/index.html
+++ b/docs/html/index.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8"/>
 <title>github.com/IrminData/irmin-sdk-go documentation</title>
 <h1>github.com/IrminData/irmin-sdk-go documentation</h1>
-<p>Generated on 2026-04-25 08:51 UTC</p>
+<p>Generated on 2026-04-25 10:57 UTC</p>
 <ul>
 <li><a href="github_com_IrminData_irmin-sdk-go.html">github.com/IrminData/irmin-sdk-go</a></li>
 <li><a href="github_com_IrminData_irmin-sdk-go_api.html">github.com/IrminData/irmin-sdk-go/api</a></li>


### PR DESCRIPTION
## Summary

Phase 4 of the connectors-client consolidation removes the
`/operation/init` round-trip on the connector service. Today, Core
calls `init` once to mint an `Operation.Token` plus cache credentials
on the connector's Operation row, and every `Start*` request
authenticates with that long-lived token. After Phase 4, `Start*`
requests must carry the credentials inline so the connector service
can upsert its Operation row inside the start handler and mint a
**per-job** operation token in the 202 response.

This SDK PR is the bottom of the Phase 4 stack:

- `StartOperationPullRequest`, `StartOperationPushRequest`, and
  `StartOperationPatchRequest` gain `Details map[string]string` and
  `Settings map[string]string` fields.
- A shared `addCredentialFormValues` / `addCredentialFormFields` pair
  emits them as `details[<key>]=<value>` / `settings[<key>]=<value>`
  form fields — the same wire shape `/operation/init` used to ship,
  so the connector-side parser does not have to change for this
  slice.
- `Extra` map entries colliding with the credential channel are
  silently dropped via `isReservedCredentialKey` so a caller cannot
  inject `details[password]` into `Extra` and overwrite a legitimate
  `Details` value.

## What this does NOT do

- Retire `/operation/init` server-side — that's the connectors-side
  Phase 4 PR.
- Mint per-job operation tokens server-side — that's the same PR.
- Switch Core's call sites to populate `Details` / `Settings` —
  that's the Core Phase 4 PR.

This SDK PR is API-additive only: existing callers keep working
because the new fields are optional. Once the connectors and Core
PRs land on top of this tag, Phase 4 closes the loop.

## Test plan

- [x] `go test ./connectorsclient/... -count=1` passes including two
      new tests:
      - `TestStartOperationPull_CarriesDetailsAndSettings` (urlencoded)
      - `TestStartOperationPatch_CarriesDetailsAndSettings` (multipart)
- [x] `golangci-lint run` clean
- [x] Reserved-key test asserts `Extra["details[password]"]` cannot
      overwrite the Details channel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches start-operation request encoding to carry credentials/scoping fields, which is security- and compatibility-sensitive (wire format and reserved-key filtering). Change is additive but could break connectors if form-field encoding/merging is wrong.
> 
> **Overview**
> Updates async `StartOperation{Pull,Push,Patch}` request types to optionally include `Details` and `Settings`, and encodes them into form fields as `details[<key>]` / `settings[<key>]` on both urlencoded (pull) and multipart (push/patch) requests.
> 
> Adds shared helpers to merge these credential fields and prevents `Extra` from overriding credential-channel keys (and `path`/`patches`/`file`/`presigned_url`), plus new tests verifying the credential/scoping fields are transmitted and that reserved-key injection via `Extra` is dropped. Documentation is regenerated to reflect the new request fields.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 418392ad87a87c4fde76d5f8fd15ac386b0eed4d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->