### PR TITLE
feat(connectorsclient): GetSchema + Subscribe credential channel (Phase 4 follow-up)

### DIFF
--- a/connectorsclient/client.go
+++ b/connectorsclient/client.go
@@ -268,6 +268,13 @@ func writeFormFile(writer *multipart.Writer, file FormFile) error {
 	return nil
 }
 
+// contentTypeFormURLEncoded is the Content-Type stamped on every
+// urlencoded request the SDK emits — exported as an unexported
+// package constant so the four call sites that emit it (
+// prepareURLEncodedBody, encodeStartPullForm, the schema POST, and
+// the config-field handlers) stay consistent and goconst-friendly.
+const contentTypeFormURLEncoded = "application/x-www-form-urlencoded"
+
 // prepareURLEncodedBody renders formFields as
 // application/x-www-form-urlencoded and sets the Content-Type header.
 func prepareURLEncodedBody(formFields map[string]string, headers map[string]string) io.Reader {
@@ -275,7 +282,7 @@ func prepareURLEncodedBody(formFields map[string]string, headers map[string]stri
 	for key, val := range formFields {
 		values.Set(key, val)
 	}
-	headers["Content-Type"] = "application/x-www-form-urlencoded"
+	headers["Content-Type"] = contentTypeFormURLEncoded
 	return strings.NewReader(values.Encode())
 }
 

--- a/connectorsclient/path_escape_test.go
+++ b/connectorsclient/path_escape_test.go
@@ -34,7 +34,12 @@ func TestGetSchemaEscapesMethodPathSegment(t *testing.T) {
 	defer srv.Close()
 
 	c := connectorsclient.NewClient(srv.URL, "tok")
-	schema, err := c.GetSchema(context.Background(), "pull/preview?mode=full", "/datasets/quarterly reports")
+	schema, err := c.GetSchema(
+		context.Background(),
+		"pull/preview?mode=full",
+		"/datasets/quarterly reports",
+		nil, nil,
+	)
 	if err != nil {
 		t.Fatalf("GetSchema: %v", err)
 	}

--- a/connectorsclient/schema.go
+++ b/connectorsclient/schema.go
@@ -14,17 +14,32 @@ import (
 // Pass an empty path for the connector's root resource.
 //
 // Schema is cheap, request-scoped metadata and stays on the sync
-// route; it does not go through the async job protocol.
-//
-// Requires an operation token on the Client.
-func (c *Client) GetSchema(ctx context.Context, method, path string) (*irminmodels.ObjectSchema, error) {
+// route; it does not go through the async job protocol. Details and
+// Settings are nevertheless required: post-Phase-4, the connector
+// service upserts the matching Operation row on every data route
+// (including schema) so the worker can read credentials on
+// connector-specific schema introspection. Pass the same maps the
+// caller would pass to StartOperation*.
+func (c *Client) GetSchema(
+	ctx context.Context,
+	method, path string,
+	details, settings map[string]string,
+) (*irminmodels.ObjectSchema, error) {
 	encodedMethod := url.PathEscape(method)
 	encodedPath := url.QueryEscape(path)
 
+	formFields := buildDetailsSettingsForm(details, settings)
+	contentType := ""
+	if len(formFields) > 0 {
+		contentType = contentTypeFormURLEncoded
+	}
+
 	var schema irminmodels.ObjectSchema
 	if err := c.FetchAPI(ctx, RequestOptions{
-		Method:   http.MethodPost,
-		Endpoint: fmt.Sprintf("/operation/schema/%s?path=%s", encodedMethod, encodedPath),
+		Method:      http.MethodPost,
+		Endpoint:    fmt.Sprintf("/operation/schema/%s?path=%s", encodedMethod, encodedPath),
+		FormFields:  formFields,
+		ContentType: contentType,
 	}, &schema); err != nil {
 		return nil, err
 	}

--- a/connectorsclient/subscribe.go
+++ b/connectorsclient/subscribe.go
@@ -23,17 +23,25 @@ type Subscription struct {
 // Subscribe is a fast, idempotent webhook-registration call; it stays
 // on the sync route and is not driven through the async job protocol.
 //
-// Requires an operation token on the Client.
-func (c *Client) SubscribeToChanges(ctx context.Context, webhookURL, webhookAccessToken string) (*Subscription, error) {
+// Phase 4: details/settings ride on the request body so the connector
+// service can upsert its Operation row inline before invoking the
+// connector-specific subscribe handler. Authenticated via the
+// connector's system token on the Client.
+func (c *Client) SubscribeToChanges(
+	ctx context.Context,
+	webhookURL, webhookAccessToken string,
+	details, settings map[string]string,
+) (*Subscription, error) {
+	formFields := buildDetailsSettingsForm(details, settings)
+	formFields["webhook_url"] = webhookURL
+	formFields["webhook_access_token"] = webhookAccessToken
+
 	var subscription Subscription
 	if err := c.FetchAPI(ctx, RequestOptions{
-		Method:   http.MethodPost,
-		Endpoint: "/operation/subscribe",
-		FormFields: map[string]string{
-			"webhook_url":          webhookURL,
-			"webhook_access_token": webhookAccessToken,
-		},
-		ContentType: "application/x-www-form-urlencoded",
+		Method:      http.MethodPost,
+		Endpoint:    "/operation/subscribe",
+		FormFields:  formFields,
+		ContentType: contentTypeFormURLEncoded,
 	}, &subscription); err != nil {
 		return nil, err
 	}
@@ -41,16 +49,20 @@ func (c *Client) SubscribeToChanges(ctx context.Context, webhookURL, webhookAcce
 }
 
 // UnsubscribeFromChanges removes a previously-registered webhook so
-// the connector stops sending change notifications.
-//
-// Requires an operation token on the Client.
-func (c *Client) UnsubscribeFromChanges(ctx context.Context, subscriptionID uint) error {
+// the connector stops sending change notifications. Same Phase-4
+// credential channel as SubscribeToChanges.
+func (c *Client) UnsubscribeFromChanges(
+	ctx context.Context,
+	subscriptionID uint,
+	details, settings map[string]string,
+) error {
+	formFields := buildDetailsSettingsForm(details, settings)
+	formFields["subscription_id"] = strconv.FormatUint(uint64(subscriptionID), 10)
+
 	return c.FetchAPI(ctx, RequestOptions{
-		Method:   http.MethodPost,
-		Endpoint: "/operation/unsubscribe",
-		FormFields: map[string]string{
-			"subscription_id": strconv.FormatUint(uint64(subscriptionID), 10),
-		},
-		ContentType: "application/x-www-form-urlencoded",
+		Method:      http.MethodPost,
+		Endpoint:    "/operation/unsubscribe",
+		FormFields:  formFields,
+		ContentType: contentTypeFormURLEncoded,
 	}, nil)
 }

--- a/docs/docs.md
+++ b/docs/docs.md
@@ -3720,13 +3720,13 @@ Authentication: Bearer tokens on every request \(system token for info/config/re
   - [func \(c \*Client\) FetchStreamFilesReader\(ctx context.Context, opts RequestOptions\) \(io.ReadCloser, error\)](<#Client.FetchStreamFilesReader>)
   - [func \(c \*Client\) GetConfigFields\(ctx context.Context, configType string, details map\[string\]string, settings map\[string\]string\) \(map\[string\]irminmodels.DynamicField, error\)](<#Client.GetConfigFields>)
   - [func \(c \*Client\) GetInfo\(ctx context.Context\) \(\*ConnectorInfo, error\)](<#Client.GetInfo>)
-  - [func \(c \*Client\) GetSchema\(ctx context.Context, method, path string\) \(\*irminmodels.ObjectSchema, error\)](<#Client.GetSchema>)
+  - [func \(c \*Client\) GetSchema\(ctx context.Context, method, path string, details, settings map\[string\]string\) \(\*irminmodels.ObjectSchema, error\)](<#Client.GetSchema>)
   - [func \(c \*Client\) Request\(ctx context.Context, opts RequestOptions\) \(\[\]byte, error\)](<#Client.Request>)
   - [func \(c \*Client\) StartOperationPatch\(ctx context.Context, req StartOperationPatchRequest\) \(\*OperationJob, error\)](<#Client.StartOperationPatch>)
   - [func \(c \*Client\) StartOperationPull\(ctx context.Context, req StartOperationPullRequest\) \(\*OperationJob, error\)](<#Client.StartOperationPull>)
   - [func \(c \*Client\) StartOperationPush\(ctx context.Context, req StartOperationPushRequest\) \(\*OperationJob, error\)](<#Client.StartOperationPush>)
-  - [func \(c \*Client\) SubscribeToChanges\(ctx context.Context, webhookURL, webhookAccessToken string\) \(\*Subscription, error\)](<#Client.SubscribeToChanges>)
-  - [func \(c \*Client\) UnsubscribeFromChanges\(ctx context.Context, subscriptionID uint\) error](<#Client.UnsubscribeFromChanges>)
+  - [func \(c \*Client\) SubscribeToChanges\(ctx context.Context, webhookURL, webhookAccessToken string, details, settings map\[string\]string\) \(\*Subscription, error\)](<#Client.SubscribeToChanges>)
+  - [func \(c \*Client\) UnsubscribeFromChanges\(ctx context.Context, subscriptionID uint, details, settings map\[string\]string\) error](<#Client.UnsubscribeFromChanges>)
   - [func \(c \*Client\) ValidateConfigFields\(ctx context.Context, details map\[string\]string, settings map\[string\]string\) \(\*irminmodels.ConnectorConfigurationValidationResult, error\)](<#Client.ValidateConfigFields>)
   - [func \(c \*Client\) WithConnectionID\(id uint\) \*Client](<#Client.WithConnectionID>)
 - [type ConnectorInfo](<#ConnectorInfo>)
@@ -3987,14 +3987,12 @@ Requires a system token on the Client.
 ### func \(\*Client\) GetSchema
 
 ```go
-func (c *Client) GetSchema(ctx context.Context, method, path string) (*irminmodels.ObjectSchema, error)
+func (c *Client) GetSchema(ctx context.Context, method, path string, details, settings map[string]string) (*irminmodels.ObjectSchema, error)
 ```
 
 GetSchema fetches the schema the connector exposes for a specific operation method \(pull / push / patch\) at the given resource path. Pass an empty path for the connector's root resource.
 
-Schema is cheap, request\-scoped metadata and stays on the sync route; it does not go through the async job protocol.
-
-Requires an operation token on the Client.
+Schema is cheap, request\-scoped metadata and stays on the sync route; it does not go through the async job protocol. Details and Settings are nevertheless required: post\-Phase\-4, the connector service upserts the matching Operation row on every data route \(including schema\) so the worker can read credentials on connector\-specific schema introspection. Pass the same maps the caller would pass to StartOperation\*.
 
 <a name="Client.Request"></a>
 ### func \(\*Client\) Request
@@ -4043,23 +4041,21 @@ StartOperationPush initiates an asynchronous push. See StartOperationPull for th
 ### func \(\*Client\) SubscribeToChanges
 
 ```go
-func (c *Client) SubscribeToChanges(ctx context.Context, webhookURL, webhookAccessToken string) (*Subscription, error)
+func (c *Client) SubscribeToChanges(ctx context.Context, webhookURL, webhookAccessToken string, details, settings map[string]string) (*Subscription, error)
 ```
 
 SubscribeToChanges registers webhookURL to receive change events. Subscribe is a fast, idempotent webhook\-registration call; it stays on the sync route and is not driven through the async job protocol.
 
-Requires an operation token on the Client.
+Phase 4: details/settings ride on the request body so the connector service can upsert its Operation row inline before invoking the connector\-specific subscribe handler. Authenticated via the connector's system token on the Client.
 
 <a name="Client.UnsubscribeFromChanges"></a>
 ### func \(\*Client\) UnsubscribeFromChanges
 
 ```go
-func (c *Client) UnsubscribeFromChanges(ctx context.Context, subscriptionID uint) error
+func (c *Client) UnsubscribeFromChanges(ctx context.Context, subscriptionID uint, details, settings map[string]string) error
 ```
 
-UnsubscribeFromChanges removes a previously\-registered webhook so the connector stops sending change notifications.
-
-Requires an operation token on the Client.
+UnsubscribeFromChanges removes a previously\-registered webhook so the connector stops sending change notifications. Same Phase\-4 credential channel as SubscribeToChanges.
 
 <a name="Client.ValidateConfigFields"></a>
 ### func \(\*Client\) ValidateConfigFields

--- a/docs/html/github_com_IrminData_irmin-sdk-go_connectorsclient.html
+++ b/docs/html/github_com_IrminData_irmin-sdk-go_connectorsclient.html
@@ -234,15 +234,21 @@ func (c *Client) GetInfo(ctx context.Context) (*ConnectorInfo, error)
 
     Requires a system token on the Client.
 
-func (c *Client) GetSchema(ctx context.Context, method, path string) (*irminmodels.ObjectSchema, error)
+func (c *Client) GetSchema(
+	ctx context.Context,
+	method, path string,
+	details, settings map[string]string,
+) (*irminmodels.ObjectSchema, error)
     GetSchema fetches the schema the connector exposes for a specific operation
     method (pull / push / patch) at the given resource path. Pass an empty path
     for the connector's root resource.
 
     Schema is cheap, request-scoped metadata and stays on the sync route;
-    it does not go through the async job protocol.
-
-    Requires an operation token on the Client.
+    it does not go through the async job protocol. Details and Settings are
+    nevertheless required: post-Phase-4, the connector service upserts the
+    matching Operation row on every data route (including schema) so the worker
+    can read credentials on connector-specific schema introspection. Pass the
+    same maps the caller would pass to StartOperation*.
 
 func (c *Client) Request(ctx context.Context, opts RequestOptions) ([]byte, error)
     Request issues an HTTP request and returns the full response body as bytes.
@@ -281,18 +287,28 @@ func (c *Client) StartOperationPush(
     StartOperationPush initiates an asynchronous push. See StartOperationPull
     for the response-status semantics.
 
-func (c *Client) SubscribeToChanges(ctx context.Context, webhookURL, webhookAccessToken string) (*Subscription, error)
+func (c *Client) SubscribeToChanges(
+	ctx context.Context,
+	webhookURL, webhookAccessToken string,
+	details, settings map[string]string,
+) (*Subscription, error)
     SubscribeToChanges registers webhookURL to receive change events. Subscribe
     is a fast, idempotent webhook-registration call; it stays on the sync route
     and is not driven through the async job protocol.
 
-    Requires an operation token on the Client.
+    Phase 4: details/settings ride on the request body so the connector service
+    can upsert its Operation row inline before invoking the connector-specific
+    subscribe handler. Authenticated via the connector's system token on the
+    Client.
 
-func (c *Client) UnsubscribeFromChanges(ctx context.Context, subscriptionID uint) error
+func (c *Client) UnsubscribeFromChanges(
+	ctx context.Context,
+	subscriptionID uint,
+	details, settings map[string]string,
+) error
     UnsubscribeFromChanges removes a previously-registered webhook so the
-    connector stops sending change notifications.
-
-    Requires an operation token on the Client.
+    connector stops sending change notifications. Same Phase-4 credential
+    channel as SubscribeToChanges.
 
 func (c *Client) ValidateConfigFields(
 	ctx context.Context,

--- a/docs/html/index.html
+++ b/docs/html/index.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8"/>
 <title>github.com/IrminData/irmin-sdk-go documentation</title>
 <h1>github.com/IrminData/irmin-sdk-go documentation</h1>
-<p>Generated on 2026-04-25 11:05 UTC</p>
+<p>Generated on 2026-04-25 11:37 UTC</p>
 <ul>
 <li><a href="github_com_IrminData_irmin-sdk-go.html">github.com/IrminData/irmin-sdk-go</a></li>
 <li><a href="github_com_IrminData_irmin-sdk-go_api.html">github.com/IrminData/irmin-sdk-go/api</a></li>


### PR DESCRIPTION
## Summary

Phase-4 follow-up to [#196](https://github.com/IrminData/irmin-sdk-go/pull/196).
That PR added `Details` / `Settings` to `StartOperation{Pull,Push,Patch}Request`
and was merged. These two cherry-picked commits were on the same
branch but didn't make it into the merge — re-shipping them as a
focused PR so the connectors-side `EnsureOperation` middleware
(coming in [irmin-connectors#180](https://github.com/IrminData/irmin-connectors/pull/180))
has a credential channel on every data route, not just Start\*.

- `GetSchema(ctx, method, path, details, settings)` — the schema
  worker introspects the external system, which needs the same
  credentials Start\* uses to authenticate.
- `SubscribeToChanges(ctx, webhookURL, webhookAccessToken, details, settings)` /
  `UnsubscribeFromChanges(ctx, subscriptionID, details, settings)` —
  webhook registration calls into the vendor on most connectors,
  same auth requirement.

Both reuse `buildDetailsSettingsForm` so the wire shape stays in
lockstep with config_fields and Start\*. New
`contentTypeFormURLEncoded` constant collapses three string
literals (goconst).

## Test plan

- [x] `go test ./connectorsclient/... -count=1` clean (existing
      `TestStartOperationPull_CarriesDetailsAndSettings` /
      `TestStartOperationPatch_CarriesDetailsAndSettings` still
      pass; `path_escape_test.go` updated to the new GetSchema
      signature)
- [x] `golangci-lint run` clean

## Downstream

- `irmin-connectors#180` re-pins to this branch's HEAD once merged.
- `irmin#440` re-pins similarly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes public client method signatures (`GetSchema`, `SubscribeToChanges`, `UnsubscribeFromChanges`) and alters request bodies/headers, which can break downstream callers and affect connector auth/operation upsert behavior.
> 
> **Overview**
> Extends sync connector routes to carry Phase-4 credentials: `GetSchema` now accepts `details`/`settings` and POSTs them as form fields when provided, and `SubscribeToChanges`/`UnsubscribeFromChanges` add the same credential channel alongside webhook/subscription parameters.
> 
> Deduplicates the urlencoded `Content-Type` string via a shared `contentTypeFormURLEncoded` constant, updates the `GetSchema` path-escaping test for the new signature, and regenerates the SDK docs to reflect the API changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a787d04191450bde5a66135ea114bb6f6fba8aa0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->