### PR TITLE
chore(connectorsclient): drop StartOperationPullResponse + ErrLegacySyncPullResponse deprecation aliases

### DIFF
--- a/connectorsclient/errors.go
+++ b/connectorsclient/errors.go
@@ -38,20 +38,11 @@ func (e *APIError) Error() string {
 // decision in the async-protocol plan.
 //
 // Returned by StartOperationPull, StartOperationPush, and
-// StartOperationPatch alike; the earlier pull-specific name
-// ErrLegacySyncPullResponse aliases this for back-compat.
+// StartOperationPatch alike.
 var ErrLegacySyncResponse = errors.New(
 	"connector returned legacy synchronous response (HTTP 200 with body); " +
 		"expected 202 Accepted from async protocol — upgrade the connector service",
 )
-
-// ErrLegacySyncPullResponse is an alias retained because the SDK PR
-// that introduced it was cited externally as a pull-specific
-// sentinel. New call sites should use ErrLegacySyncResponse.
-//
-// Deprecated: use ErrLegacySyncResponse. Kept for one release cycle
-// so existing errors.Is checks keep matching.
-var ErrLegacySyncPullResponse = ErrLegacySyncResponse
 
 // ErrResultNotReady is returned by FetchOperationResult when the job
 // is still in a non-terminal state (pending or running) at the time

--- a/connectorsclient/operation_async_test.go
+++ b/connectorsclient/operation_async_test.go
@@ -248,7 +248,7 @@ func TestStartOperationPatch_CarriesDetailsAndSettings(t *testing.T) {
 }
 
 // TestStartOperationPull_LegacySyncResponse verifies that a 200 OK
-// from an unmigrated connector surfaces the ErrLegacySyncPullResponse
+// from an unmigrated connector surfaces the ErrLegacySyncResponse
 // sentinel rather than silently degrading to a sync path.
 func TestStartOperationPull_LegacySyncResponse(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -263,8 +263,8 @@ func TestStartOperationPull_LegacySyncResponse(t *testing.T) {
 		context.Background(),
 		connectorsclient.StartOperationPullRequest{Path: "/v1/customers"},
 	)
-	if !errors.Is(err, connectorsclient.ErrLegacySyncPullResponse) {
-		t.Fatalf("err = %v, want ErrLegacySyncPullResponse", err)
+	if !errors.Is(err, connectorsclient.ErrLegacySyncResponse) {
+		t.Fatalf("err = %v, want ErrLegacySyncResponse", err)
 	}
 }
 

--- a/docs/docs.md
+++ b/docs/docs.md
@@ -3770,17 +3770,9 @@ const HeaderConnectionID = "X-Irmin-Connection-Id"
 var ErrJobFailed = errors.New("operation job ended in a non-success terminal state")
 ```
 
-<a name="ErrLegacySyncPullResponse"></a>ErrLegacySyncPullResponse is an alias retained because the SDK PR that introduced it was cited externally as a pull\-specific sentinel. New call sites should use ErrLegacySyncResponse.
-
-Deprecated: use ErrLegacySyncResponse. Kept for one release cycle so existing errors.Is checks keep matching.
-
-```go
-var ErrLegacySyncPullResponse = ErrLegacySyncResponse
-```
-
 <a name="ErrLegacySyncResponse"></a>ErrLegacySyncResponse is returned by any Start\*Operation call when the connector service responds with a 200 OK \+ body instead of the expected 202 Accepted \+ \{job\_id, operation\_token\}. Its presence means the connector service is still on the pre\-async protocol and the caller is talking to an unmigrated deployment; the Core poll wrapper should bail out with an actionable message rather than attempt a silent fallback, per the "no backward\-compat shim" decision in the async\-protocol plan.
 
-Returned by StartOperationPull, StartOperationPush, and StartOperationPatch alike; the earlier pull\-specific name ErrLegacySyncPullResponse aliases this for back\-compat.
+Returned by StartOperationPull, StartOperationPush, and StartOperationPatch alike.
 
 ```go
 var ErrLegacySyncResponse = errors.New(
@@ -4908,7 +4900,6 @@ import "github.com/IrminData/irmin-sdk-go/models"
 - [type SearchResult](<#SearchResult>)
 - [type SelectOption](<#SelectOption>)
 - [type StartOperationJobResponse](<#StartOperationJobResponse>)
-- [type StartOperationPullResponse](<#StartOperationPullResponse>)
 - [type StoredQuery](<#StoredQuery>)
 - [type StoredScript](<#StoredScript>)
 - [type SubscriptionStatus](<#SubscriptionStatus>)
@@ -6305,9 +6296,9 @@ const (
 <a name="OperationJob"></a>
 ## type OperationJob
 
-OperationJob is the metadata record for an asynchronous connector operation \(currently: pull; push/patch to follow\).
+OperationJob is the metadata record for an asynchronous connector operation \(pull / push / patch\).
 
-The connector service creates one of these on POST /operation/pull, returns its ID to the caller, then fills in status/progress as the worker runs. The full job payload is typically only returned inside status responses; POST /operation/pull itself returns the slimmer StartOperationPullResponse to keep the accept\-fast path fast.
+The connector service creates one of these on POST /operation/\{pull, push,patch\}, returns its ID \+ per\-job operation token to the caller in StartOperationJobResponse, then fills in status/progress as the worker runs. The full job payload is typically only returned inside status responses; the start route itself returns the slimmer StartOperationJobResponse to keep the accept\-fast path fast.
 
 ```go
 type OperationJob struct {
@@ -7455,17 +7446,6 @@ type StartOperationJobResponse struct {
     // underlying OperationJob row.
     OperationToken string `json:"operation_token" example:"optk_7f3d2a9c1e6b"`
 }
-```
-
-<a name="StartOperationPullResponse"></a>
-## type StartOperationPullResponse
-
-StartOperationPullResponse is the legacy name for StartOperationJobResponse. Kept as an alias so existing connector\-service handlers compile unchanged while the rename propagates.
-
-Deprecated: use StartOperationJobResponse.
-
-```go
-type StartOperationPullResponse = StartOperationJobResponse
 ```
 
 <a name="StoredQuery"></a>

--- a/docs/html/github_com_IrminData_irmin-sdk-go_connectorsclient.html
+++ b/docs/html/github_com_IrminData_irmin-sdk-go_connectorsclient.html
@@ -49,14 +49,6 @@ var ErrJobFailed = errors.New("operation job ended in a non-success terminal sta
     wrap this can surface the original connector-supplied error message from
     OperationJobStatusResponse.Error.
 
-var ErrLegacySyncPullResponse = ErrLegacySyncResponse
-    ErrLegacySyncPullResponse is an alias retained because the SDK PR that
-    introduced it was cited externally as a pull-specific sentinel. New call
-    sites should use ErrLegacySyncResponse.
-
-    Deprecated: use ErrLegacySyncResponse. Kept for one release cycle so
-    existing errors.Is checks keep matching.
-
 var ErrLegacySyncResponse = errors.New(
 	"connector returned legacy synchronous response (HTTP 200 with body); " +
 		"expected 202 Accepted from async protocol — upgrade the connector service",
@@ -70,8 +62,7 @@ var ErrLegacySyncResponse = errors.New(
     backward-compat shim" decision in the async-protocol plan.
 
     Returned by StartOperationPull, StartOperationPush, and StartOperationPatch
-    alike; the earlier pull-specific name ErrLegacySyncPullResponse aliases this
-    for back-compat.
+    alike.
 
 var ErrMissingOperationToken = errors.New(
 	"connector accepted the operation (HTTP 202) but did not return an operation_token; " +

--- a/docs/html/github_com_IrminData_irmin-sdk-go_models.html
+++ b/docs/html/github_com_IrminData_irmin-sdk-go_models.html
@@ -986,13 +986,14 @@ type OperationJob struct {
 	ExpiresAt *time.Time `json:"expires_at,omitempty"`
 }
     OperationJob is the metadata record for an asynchronous connector operation
-    (currently: pull; push/patch to follow).
+    (pull / push / patch).
 
-    The connector service creates one of these on POST /operation/pull, returns
-    its ID to the caller, then fills in status/progress as the worker runs.
+    The connector service creates one of these on POST /operation/{pull,
+    push,patch}, returns its ID + per-job operation token to the caller in
+    StartOperationJobResponse, then fills in status/progress as the worker runs.
     The full job payload is typically only returned inside status responses;
-    POST /operation/pull itself returns the slimmer StartOperationPullResponse
-    to keep the accept-fast path fast.
+    the start route itself returns the slimmer StartOperationJobResponse to keep
+    the accept-fast path fast.
 
 type OperationJobStatus string
     OperationJobStatus enumerates the lifecycle states of an asynchronous
@@ -1745,13 +1746,6 @@ type StartOperationJobResponse struct {
     The SDK's Client.StartOperation{Pull,Push,Patch} converts this body into a
     *connectorsclient.OperationJob handle that encapsulates the token so callers
     never pass it around manually.
-
-type StartOperationPullResponse = StartOperationJobResponse
-    StartOperationPullResponse is the legacy name for StartOperationJobResponse.
-    Kept as an alias so existing connector-service handlers compile unchanged
-    while the rename propagates.
-
-    Deprecated: use StartOperationJobResponse.
 
 type StoredQuery struct {
 	ID          string    `json:"id"             validate:"required,validsqid=queries" example:"query_1a2b3c4d5e"`

--- a/docs/html/index.html
+++ b/docs/html/index.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8"/>
 <title>github.com/IrminData/irmin-sdk-go documentation</title>
 <h1>github.com/IrminData/irmin-sdk-go documentation</h1>
-<p>Generated on 2026-04-25 14:02 UTC</p>
+<p>Generated on 2026-04-25 14:08 UTC</p>
 <ul>
 <li><a href="github_com_IrminData_irmin-sdk-go.html">github.com/IrminData/irmin-sdk-go</a></li>
 <li><a href="github_com_IrminData_irmin-sdk-go_api.html">github.com/IrminData/irmin-sdk-go/api</a></li>

--- a/docs/html/index.html
+++ b/docs/html/index.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8"/>
 <title>github.com/IrminData/irmin-sdk-go documentation</title>
 <h1>github.com/IrminData/irmin-sdk-go documentation</h1>
-<p>Generated on 2026-04-25 14:08 UTC</p>
+<p>Generated on 2026-04-25 14:14 UTC</p>
 <ul>
 <li><a href="github_com_IrminData_irmin-sdk-go.html">github.com/IrminData/irmin-sdk-go</a></li>
 <li><a href="github_com_IrminData_irmin-sdk-go_api.html">github.com/IrminData/irmin-sdk-go/api</a></li>

--- a/docs/html/index.html
+++ b/docs/html/index.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8"/>
 <title>github.com/IrminData/irmin-sdk-go documentation</title>
 <h1>github.com/IrminData/irmin-sdk-go documentation</h1>
-<p>Generated on 2026-04-25 11:37 UTC</p>
+<p>Generated on 2026-04-25 14:02 UTC</p>
 <ul>
 <li><a href="github_com_IrminData_irmin-sdk-go.html">github.com/IrminData/irmin-sdk-go</a></li>
 <li><a href="github_com_IrminData_irmin-sdk-go_api.html">github.com/IrminData/irmin-sdk-go/api</a></li>

--- a/models/operation_job.go
+++ b/models/operation_job.go
@@ -60,13 +60,14 @@ func (s OperationJobStatus) IsTerminal() bool {
 }
 
 // OperationJob is the metadata record for an asynchronous connector
-// operation (currently: pull; push/patch to follow).
+// operation (pull / push / patch).
 //
-// The connector service creates one of these on POST /operation/pull,
-// returns its ID to the caller, then fills in status/progress as the
+// The connector service creates one of these on POST /operation/{pull,
+// push,patch}, returns its ID + per-job operation token to the caller
+// in StartOperationJobResponse, then fills in status/progress as the
 // worker runs. The full job payload is typically only returned inside
-// status responses; POST /operation/pull itself returns the slimmer
-// StartOperationPullResponse to keep the accept-fast path fast.
+// status responses; the start route itself returns the slimmer
+// StartOperationJobResponse to keep the accept-fast path fast.
 type OperationJob struct {
 	// JobID is the connector-service-issued identifier for this job.
 	// Opaque to clients — used to poll status, fetch result, or
@@ -170,13 +171,6 @@ type StartOperationJobResponse struct {
 	// underlying OperationJob row.
 	OperationToken string `json:"operation_token" example:"optk_7f3d2a9c1e6b"`
 }
-
-// StartOperationPullResponse is the legacy name for StartOperationJobResponse.
-// Kept as an alias so existing connector-service handlers compile unchanged
-// while the rename propagates.
-//
-// Deprecated: use StartOperationJobResponse.
-type StartOperationPullResponse = StartOperationJobResponse
 
 // AlreadyRunningBody is the wire shape returned by any connector
 // endpoint that refuses a request because the same operation is


### PR DESCRIPTION
## Summary

Both aliases were declared with explicit \`// Deprecated:\` comments stating
"kept for one release cycle". That cycle shipped with #196 and #197
merged on \`development\`. Removing them.

- **\`StartOperationPullResponse\`** (\`models/operation_job.go\`) — type
  alias for \`StartOperationJobResponse\`. Zero non-test consumers
  anywhere in the SDK; the consolidation already migrated Core and
  \`irmin-connectors\` off the deprecated name when those PRs landed.
  The \`OperationJob\` doc comment that name-referenced the alias is
  rewritten.
- **\`ErrLegacySyncPullResponse\`** (\`connectorsclient/errors.go\`) —
  variable alias for \`ErrLegacySyncResponse\`. One in-tree consumer:
  \`TestStartOperationPull_LegacySyncResponse\` updated to use the
  canonical name. Test contract unchanged.

## Test plan

- [x] \`go test ./... -count=1\` clean — \`TestStartOperationPull_LegacySyncResponse\`
      still asserts the legacy-sync sentinel surfaces.
- [x] \`golangci-lint run\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Removes exported deprecated aliases (`ErrLegacySyncPullResponse` and `StartOperationPullResponse`), which is a breaking change for any downstream code still referencing them despite prior deprecation.
> 
> **Overview**
> Drops the one-release deprecation shims by removing `ErrLegacySyncPullResponse` (now only `ErrLegacySyncResponse`) and the `StartOperationPullResponse` type alias (standardizing on `StartOperationJobResponse`). Updates the async operation pull test and generated docs/comments to reference the canonical names and the generalized pull/push/patch async job API.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de2af6460acbb6afe6308d3bbb5b0c589bb620fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->