### PR TITLE
ci(lint): enable golangci-lint-action build cache

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -32,7 +32,12 @@ jobs:
         with:
           version: v2.6.1
           args: --timeout=5m
-          skip-cache: true
+          # skip-cache was true historically, which made every run
+          # analyse the full module from cold and pushed the lint
+          # job toward its timeout ceiling. The action's built-in
+          # cache keys on go.sum + tool version, so warm starts
+          # across PRs are safe and produce the expected speedup.
+          skip-cache: false
 
       - name: Create or update PR comment on failure
         if: failure()

--- a/docs/html/index.html
+++ b/docs/html/index.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8"/>
 <title>github.com/IrminData/irmin-sdk-go documentation</title>
 <h1>github.com/IrminData/irmin-sdk-go documentation</h1>
-<p>Generated on 2026-04-25 11:37 UTC</p>
+<p>Generated on 2026-04-25 14:03 UTC</p>
 <ul>
 <li><a href="github_com_IrminData_irmin-sdk-go.html">github.com/IrminData/irmin-sdk-go</a></li>
 <li><a href="github_com_IrminData_irmin-sdk-go_api.html">github.com/IrminData/irmin-sdk-go/api</a></li>


### PR DESCRIPTION
## Summary

\`skip-cache=true\` was set on \`golangci/golangci-lint-action@v8\`, which
defeated the action's built-in build cache. Every PR run analysed the
full module from cold. The Phase-4 \`irmin\` PR (#440) hit this as a
5-minute-timeout failure — lint produced \`0 issues\` but the action
exited code 4. The Core repo bumped its \`--timeout\` to 10m as a
band-aid; the real fix is enabling the cache. Same change going to
all three Go repos (this PR + companion PRs on irmin-connectors and
irmin).

## Why this is safe

The action's cache keys on \`go.sum\` + the resolved golangci-lint
version. Both only change on dependency or toolchain bumps, so warm
starts across PRs share the same input set the prior run analysed —
no risk of stale-cache false-positives or false-negatives.

## Test plan

- [ ] First CI run is still cold (no prior cache) — should match the
      historical baseline.
- [ ] Second run on the same branch (or a follow-up PR) should be
      noticeably faster — well under the 5-minute ceiling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: CI-only change that enables lint caching to reduce runtime/timeouts; no production code paths are modified.
> 
> **Overview**
> **Speeds up CI lint runs** by enabling the built-in cache in `golangci/golangci-lint-action` (`skip-cache: false`) and documenting why warm cache reuse is safe.
> 
> Regenerates `docs/html/index.html` with an updated *Generated on* timestamp only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8468544a672f3b91f2e4a26104f02fce69f218f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->