### PR TITLE
docs: fix dangling references to deleted ErrLegacySyncPullResponse alias

### DIFF
--- a/connectorsclient/operation_async.go
+++ b/connectorsclient/operation_async.go
@@ -162,7 +162,7 @@ type StartOperationPatchRequest struct {
 //
 //   - 202 Accepted — job queued; returns the handle.
 //   - 200 OK — the connector service is on the pre-async protocol.
-//     Returns ErrLegacySyncPullResponse without draining the body
+//     Returns ErrLegacySyncResponse without draining the body
 //     (which could be a multi-gigabyte zip).
 //   - 409 Conflict — an operation is already running for this
 //     connection. Returns *AlreadyRunningError carrying the blocking

--- a/docs/docs.md
+++ b/docs/docs.md
@@ -4016,7 +4016,7 @@ StartOperationPull initiates an asynchronous pull against a connector. The Clien
 Semantics by response status:
 
 - 202 Accepted — job queued; returns the handle.
-- 200 OK — the connector service is on the pre\-async protocol. Returns ErrLegacySyncPullResponse without draining the body \(which could be a multi\-gigabyte zip\).
+- 200 OK — the connector service is on the pre\-async protocol. Returns ErrLegacySyncResponse without draining the body \(which could be a multi\-gigabyte zip\).
 - 409 Conflict — an operation is already running for this connection. Returns \*AlreadyRunningError carrying the blocking job\_id when the server emits a structured body, \*APIError otherwise.
 - Any other non\-2xx — \*APIError.
 
@@ -7425,7 +7425,7 @@ type SelectOption struct {
 <a name="StartOperationJobResponse"></a>
 ## type StartOperationJobResponse
 
-StartOperationJobResponse is the body returned by POST /operation/pull, /operation/push, and /operation/patch under the async protocol. The HTTP status is 202 Accepted; a legacy 200 with a zip body is reported as ErrLegacySyncPullResponse.
+StartOperationJobResponse is the body returned by POST /operation/pull, /operation/push, and /operation/patch under the async protocol. The HTTP status is 202 Accepted; a legacy 200 with a zip body is reported as ErrLegacySyncResponse.
 
 The response carries two fields:
 

--- a/docs/html/github_com_IrminData_irmin-sdk-go_connectorsclient.html
+++ b/docs/html/github_com_IrminData_irmin-sdk-go_connectorsclient.html
@@ -264,7 +264,7 @@ func (c *Client) StartOperationPull(
 
       - 202 Accepted — job queued; returns the handle.
       - 200 OK — the connector service is on the pre-async protocol. Returns
-        ErrLegacySyncPullResponse without draining the body (which could be a
+        ErrLegacySyncResponse without draining the body (which could be a
         multi-gigabyte zip).
       - 409 Conflict — an operation is already running for this connection.
         Returns *AlreadyRunningError carrying the blocking job_id when the

--- a/docs/html/github_com_IrminData_irmin-sdk-go_models.html
+++ b/docs/html/github_com_IrminData_irmin-sdk-go_models.html
@@ -1729,7 +1729,7 @@ type StartOperationJobResponse struct {
     StartOperationJobResponse is the body returned by POST /operation/pull,
     /operation/push, and /operation/patch under the async protocol. The HTTP
     status is 202 Accepted; a legacy 200 with a zip body is reported as
-    ErrLegacySyncPullResponse.
+    ErrLegacySyncResponse.
 
     The response carries two fields:
 

--- a/docs/html/index.html
+++ b/docs/html/index.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8"/>
 <title>github.com/IrminData/irmin-sdk-go documentation</title>
 <h1>github.com/IrminData/irmin-sdk-go documentation</h1>
-<p>Generated on 2026-04-25 14:14 UTC</p>
+<p>Generated on 2026-04-25 15:28 UTC</p>
 <ul>
 <li><a href="github_com_IrminData_irmin-sdk-go.html">github.com/IrminData/irmin-sdk-go</a></li>
 <li><a href="github_com_IrminData_irmin-sdk-go_api.html">github.com/IrminData/irmin-sdk-go/api</a></li>

--- a/docs/html/index.html
+++ b/docs/html/index.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8"/>
 <title>github.com/IrminData/irmin-sdk-go documentation</title>
 <h1>github.com/IrminData/irmin-sdk-go documentation</h1>
-<p>Generated on 2026-04-25 15:28 UTC</p>
+<p>Generated on 2026-04-25 15:29 UTC</p>
 <ul>
 <li><a href="github_com_IrminData_irmin-sdk-go.html">github.com/IrminData/irmin-sdk-go</a></li>
 <li><a href="github_com_IrminData_irmin-sdk-go_api.html">github.com/IrminData/irmin-sdk-go/api</a></li>

--- a/models/operation_job.go
+++ b/models/operation_job.go
@@ -143,7 +143,7 @@ type OperationJobStatusResponse struct {
 // StartOperationJobResponse is the body returned by
 // POST /operation/pull, /operation/push, and /operation/patch under
 // the async protocol. The HTTP status is 202 Accepted; a legacy 200
-// with a zip body is reported as ErrLegacySyncPullResponse.
+// with a zip body is reported as ErrLegacySyncResponse.
 //
 // The response carries two fields:
 //


### PR DESCRIPTION
## Summary

- PR #198 dropped the \`ErrLegacySyncPullResponse\` deprecation alias but left two doc-comments still naming it. Actual code paths already use the canonical \`ErrLegacySyncResponse\`; this just brings the docs in line.

## Files

- \`connectorsclient/operation_async.go\` — \`StartOperationPull\` doc-comment (line 165)
- \`models/operation_job.go\` — \`StartOperationJobResponse\` doc-comment (line 146)
- \`docs/{docs.md,html/*}\` — regenerated via \`bash generate-docs.sh\`

## Test plan

- [x] \`go build ./...\`
- [x] \`go test ./connectorsclient/... -count=1 -timeout 60s\`
- [x] \`golangci-lint run\` — \`0 issues\`
- [x] \`bash generate-docs.sh\` — regenerated cleanly
- [x] \`rg ErrLegacySyncPullResponse\` — zero hits

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only changes plus regenerated output; no runtime logic or API behavior changes.
> 
> **Overview**
> Updates the `StartOperationPull` and `StartOperationJobResponse` doc comments to reference `ErrLegacySyncResponse` (the canonical error) instead of the removed `ErrLegacySyncPullResponse` alias.
> 
> Regenerates `docs.md` and the HTML docs to reflect the corrected error name (and updates the generated timestamp).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3eb340c4bb506a526f1d5ac7007529a3b333cf3e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->